### PR TITLE
DVT-#21 회원가입 페이지 레이아웃 추가

### DIFF
--- a/src/components/Signup/Signup.test.tsx
+++ b/src/components/Signup/Signup.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Signup from "./Signup";
+
+beforeEach(() => {
+  render(<Signup />, { wrapper: MemoryRouter });
+});
+
+describe("회원가입 페이지", () => {
+  it("회원가입 문구가 보여야 한다.", () => {
+    const titleElement = screen.getByRole("heading", {
+      name: "회원가입",
+      level: 1,
+    });
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  it("이름 입력 폼이 보여야 한다.", () => {
+    const nameElement = screen.getByPlaceholderText("이름") as HTMLInputElement;
+    expect(nameElement).toBeInTheDocument();
+  });
+
+  it("이메일 입력 폼이 보여야 한다.", () => {
+    const emailElement = screen.getByPlaceholderText(
+      "이메일"
+    ) as HTMLInputElement;
+    expect(emailElement).toBeInTheDocument();
+  });
+
+  it("비밀번호 입력 폼이 보여야 한다.", () => {
+    const passwordElement = screen.getByPlaceholderText(
+      "비밀번호"
+    ) as HTMLInputElement;
+    expect(passwordElement).toBeInTheDocument();
+  });
+
+  it("비밀번호 확인 입력 폼이 보여야 한다.", () => {
+    const confirmPasswordElement = screen.getByPlaceholderText(
+      "비밀번호 확인"
+    ) as HTMLInputElement;
+    expect(confirmPasswordElement).toBeInTheDocument();
+  });
+
+  it("코스를 선택할 수 있는 드랍다운폼이 보여야 한다.", () => {
+    const course = screen.getByLabelText("코스");
+    expect(course).toBeInTheDocument();
+  });
+
+  it("기수를 선택할 수 있는 드랍다운폼이 보여야 한다.", () => {
+    const generation = screen.getByLabelText("기수");
+    expect(generation).toBeInTheDocument();
+  });
+
+  it("역할을 선택할 수 있는 드랍다운폼이 보여야 한다.", () => {
+    const role = screen.getByLabelText("역할");
+    expect(role).toBeInTheDocument();
+  });
+
+  it("회원가입 버튼이 보여야 한다.", () => {
+    const signupButton = screen.getByRole("button", { name: "회원가입" });
+    expect(signupButton).toBeInTheDocument();
+  });
+});

--- a/src/components/Signup/Signup.tsx
+++ b/src/components/Signup/Signup.tsx
@@ -1,0 +1,72 @@
+import { FormEvent } from "react";
+import { useHistory } from "react-router-dom";
+import { HiddenParagraph, SignupContainer, SignupForm } from "./styles";
+
+const courses: string[] = ["백엔드", "프론트엔드", "인공지능"];
+const generations: string[] = ["1기", "2기"];
+const roles: string[] = ["매니저", "수강생", "멘토"];
+
+const Signup = () => {
+  const history = useHistory();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    history.push("/");
+  };
+
+  return (
+    <SignupContainer>
+      <h1>회원가입</h1>
+
+      <SignupForm onSubmit={handleSubmit}>
+        <input type="text" name="name" placeholder="이름" />
+        <input type="text" name="email" placeholder="이메일" />
+        <input type="password" name="password" placeholder="비밀번호" />
+        <input
+          type="password"
+          name="confirmPassword"
+          placeholder="비밀번호 확인"
+        />
+        <label htmlFor="course">
+          <HiddenParagraph>코스</HiddenParagraph>
+          <select id="course" name="course">
+            <option value="">코스를 선택해주세요.</option>
+            {courses.map((course) => (
+              <option key={course} value={course}>
+                {course}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label htmlFor="generation">
+          <HiddenParagraph>기수</HiddenParagraph>
+          <select id="generation" name="generation">
+            <option value="">기수를 선택해주세요.</option>
+            {generations.map((generation) => (
+              <option key={generation} value={generation}>
+                {generation}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label htmlFor="role">
+          <HiddenParagraph>역할</HiddenParagraph>
+          <select id="role" name="role">
+            <option value="">역할을 선택해주세요.</option>
+            {roles.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button type="submit">회원가입</button>
+      </SignupForm>
+    </SignupContainer>
+  );
+};
+
+export default Signup;

--- a/src/components/Signup/SignupContainer.tsx
+++ b/src/components/Signup/SignupContainer.tsx
@@ -1,0 +1,7 @@
+import Signup from "./Signup";
+
+const SignupContainer = () => {
+  return <Signup />;
+};
+
+export default SignupContainer;

--- a/src/components/Signup/styles.ts
+++ b/src/components/Signup/styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const SignupContainer = styled.div``;
+
+export const SignupForm = styled.form`
+  display: inline-flex;
+  flex-direction: column;
+`;
+
+export const HiddenParagraph = styled.p`
+  display: none;
+`;

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,0 +1,7 @@
+import SignupContainer from "../../components/Signup/SignupContainer";
+
+const index = () => {
+  return <SignupContainer />;
+};
+
+export default index;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,12 +1,13 @@
 import { Route, Switch } from "react-router-dom";
 import MainPage from "../pages/MainPage";
 import LoginPage from "../pages/LoginPage";
+import SignupPage from "../pages/SignupPage";
 
 const Router = () => {
   return (
     <Switch>
       <Route path="/" exact component={MainPage} />
-      <Route path="/signup" exact component={MainPage} />
+      <Route path="/signup" exact component={SignupPage} />
       <Route path="/login" exact component={LoginPage} />
       <Route path="/admin" exact component={MainPage} />
       <Route path="/myprofile" exact component={MainPage} />


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

- 회원가입 페이지 레이아웃을 추가 한다.
- 레이아웃 관련 테스트 파일을 추가 한다.
- Router에 SignupPage을 추가 한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #21 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 이름, 이메일, 비밀번호, 비밀번호 확인, 코스, 기수, 역할의 input element가 존재해야 한다.
- [ ] 회원가입 버튼을 누르면 메인페이지로 라우팅되어야 한다.

테스트 결과
![image](https://user-images.githubusercontent.com/52060742/144697273-b550c2a9-5b48-4438-9935-0e4dd369e409.png)


## 변경된 내용

> 가능하다면 스크린샷을 첨부해주세요.

![image](https://user-images.githubusercontent.com/52060742/144697320-d1ccf3d2-5e28-4031-9ac9-4b81479f7331.png)


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 회원가입 버튼을 눌렀을 때 `useLocation` 이나 `useHistory` 를 사용하여 정확히 페이지가 변경되었는지 테스트 하고 싶었는데 방법을 아직 찾지 못했습니다. 그래서 이 부분은 일단 생략하고 진행하였습니다. 추후 방법을 찾게되면 따로 공지하겠습니다.
