### PR TITLE
DVT-#27 로그인 페이지 폼 유효성 체크

### DIFF
--- a/src/components/Login/Login.test.tsx
+++ b/src/components/Login/Login.test.tsx
@@ -1,18 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
-import Login from "./Login";
+import { login } from "../../utils/constants";
+import LoginContainer from "./LoginContainer";
 
 beforeEach(() => {
   render(
     <BrowserRouter>
-      <Login />
+      <LoginContainer />
     </BrowserRouter>
   );
 });
 
-describe("로그인 Presenter 컴포넌트", () => {
+afterEach(cleanup);
+
+describe("로그인 컴포넌트 레이아웃", () => {
   it("Devnity 문구가 보여야 한다.", () => {
-    const titleElement = screen.getByText(/Devnity/i);
+    const titleElement = screen.getByText(/Devnity/i) as HTMLHeadingElement;
     expect(titleElement).toBeInTheDocument();
   });
 
@@ -31,7 +40,9 @@ describe("로그인 Presenter 컴포넌트", () => {
   });
 
   it("로그인 버튼이 보여야 한다.", () => {
-    const loginButton = screen.getByRole("button", { name: "로그인" });
+    const loginButton = screen.getByRole("button", {
+      name: "로그인",
+    }) as HTMLButtonElement;
     expect(loginButton).toBeInTheDocument();
   });
 
@@ -39,7 +50,6 @@ describe("로그인 Presenter 컴포넌트", () => {
     const signupLink = screen.getByRole("link", {
       name: "회원가입",
     }) as HTMLAnchorElement;
-
     expect(signupLink).toHaveAttribute("href", "/signup");
   });
 
@@ -47,7 +57,68 @@ describe("로그인 Presenter 컴포넌트", () => {
     const findPasswordLink = screen.getByRole("link", {
       name: "비밀번호를 잊으셨나요?",
     }) as HTMLAnchorElement;
-
     expect(findPasswordLink).toHaveAttribute("href", "/findpassword");
+  });
+});
+
+describe("로그인 컴포넌트 form 정합성 체크", () => {
+  it(`사용자가 이메일을 입력하지 않고 로그인 버튼을 누르면 '${login.message.EMAIL_REQUIRED_VALIDATION}' 문구가 보여야 한다.`, async () => {
+    const loginButton = screen.getByRole("button", { name: "로그인" });
+
+    await waitFor(() => {
+      fireEvent.click(loginButton);
+    });
+
+    const errorMessage = screen.getByText(
+      login.message.EMAIL_REQUIRED_VALIDATION
+    ) as HTMLParagraphElement;
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it(`사용자가 올바르지 않은 이메일 형식을 입력했을 경우 '${login.message.EMAIL_FORMAT_VALIDATION}' 문구가 보여야 한다.`, async () => {
+    const emailElement = screen.getByPlaceholderText(
+      "이메일"
+    ) as HTMLInputElement;
+
+    await waitFor(() => {
+      fireEvent.change(emailElement, {
+        target: { value: "abc" },
+      });
+    });
+
+    const errorMessage = screen.getByText(
+      login.message.EMAIL_FORMAT_VALIDATION
+    ) as HTMLParagraphElement;
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it(`사용자가 올바른 형식의 이메일을 입력했을 경우 에러메세지가 보이지 않는다.`, async () => {
+    const emailElement = screen.getByPlaceholderText(
+      "이메일"
+    ) as HTMLInputElement;
+
+    await waitFor(() => {
+      fireEvent.change(emailElement, {
+        target: { value: "rkdvnfma90@gmail.com" },
+      });
+    });
+
+    const errorMessage = screen.queryByText(
+      login.message.EMAIL_FORMAT_VALIDATION
+    ) as HTMLParagraphElement;
+    expect(errorMessage).not.toBeInTheDocument();
+  });
+
+  it(`사용자가 비밀번호를 입력하지 않고 로그인 버튼을 누르면 '${login.message.PASSWORD_REQUIRED_VALIDATION}' 문구가 보여야 한다.`, async () => {
+    const loginButton = screen.getByRole("button", { name: "로그인" });
+
+    await waitFor(() => {
+      fireEvent.click(loginButton);
+    });
+
+    const errorMessage = screen.getByText(
+      login.message.PASSWORD_REQUIRED_VALIDATION
+    ) as HTMLParagraphElement;
+    expect(errorMessage).toBeInTheDocument();
   });
 });

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,7 +1,13 @@
 import { Link } from "react-router-dom";
-import { LoginContainer, LoginForm } from "./styles";
+import { FormikProps } from "formik";
+import { LoginContainer, LoginForm, ErrorMessage } from "./styles";
+import { FormValues } from "./types";
 
-const LoginPresenter = () => {
+interface IProps {
+  formik: FormikProps<FormValues>;
+}
+
+const Login = ({ formik }: IProps) => {
   return (
     <LoginContainer>
       <p>
@@ -9,9 +15,27 @@ const LoginPresenter = () => {
       </p>
       <h1>Devnity</h1>
 
-      <LoginForm>
-        <input type="text" placeholder="이메일" />
-        <input type="password" placeholder="비밀번호" />
+      <LoginForm onSubmit={formik.handleSubmit} autoComplete="off">
+        <input
+          name="email"
+          type="email"
+          placeholder="이메일"
+          onChange={formik.handleChange}
+          value={formik.values.email}
+        />
+        {formik.errors.email ? (
+          <ErrorMessage>{formik.errors.email}</ErrorMessage>
+        ) : null}
+        <input
+          name="password"
+          type="password"
+          placeholder="비밀번호"
+          onChange={formik.handleChange}
+          value={formik.values.password}
+        />
+        {formik.errors.password ? (
+          <ErrorMessage>{formik.errors.password}</ErrorMessage>
+        ) : null}
 
         <Link to="/findpassword">비밀번호를 잊으셨나요?</Link>
 
@@ -21,4 +45,4 @@ const LoginPresenter = () => {
   );
 };
 
-export default LoginPresenter;
+export default Login;

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -21,9 +21,10 @@ const Login = ({ formik }: IProps) => {
           type="email"
           placeholder="이메일"
           onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
           value={formik.values.email}
         />
-        {formik.errors.email ? (
+        {formik.touched.email && formik.errors.email ? (
           <ErrorMessage>{formik.errors.email}</ErrorMessage>
         ) : null}
         <input
@@ -31,9 +32,10 @@ const Login = ({ formik }: IProps) => {
           type="password"
           placeholder="비밀번호"
           onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
           value={formik.values.password}
         />
-        {formik.errors.password ? (
+        {formik.touched.password && formik.errors.password ? (
           <ErrorMessage>{formik.errors.password}</ErrorMessage>
         ) : null}
 

--- a/src/components/Login/LoginContainer.test.tsx
+++ b/src/components/Login/LoginContainer.test.tsx
@@ -22,6 +22,7 @@ afterEach(cleanup);
 describe("로그인 컴포넌트 레이아웃", () => {
   it("Devnity 문구가 보여야 한다.", () => {
     const titleElement = screen.getByText(/Devnity/i) as HTMLHeadingElement;
+
     expect(titleElement).toBeInTheDocument();
   });
 
@@ -29,6 +30,7 @@ describe("로그인 컴포넌트 레이아웃", () => {
     const emailElement = screen.getByPlaceholderText(
       "이메일"
     ) as HTMLInputElement;
+
     expect(emailElement).toBeInTheDocument();
   });
 
@@ -36,6 +38,7 @@ describe("로그인 컴포넌트 레이아웃", () => {
     const passwordElement = screen.getByPlaceholderText(
       "비밀번호"
     ) as HTMLInputElement;
+
     expect(passwordElement).toBeInTheDocument();
   });
 
@@ -43,6 +46,7 @@ describe("로그인 컴포넌트 레이아웃", () => {
     const loginButton = screen.getByRole("button", {
       name: "로그인",
     }) as HTMLButtonElement;
+
     expect(loginButton).toBeInTheDocument();
   });
 
@@ -50,6 +54,7 @@ describe("로그인 컴포넌트 레이아웃", () => {
     const signupLink = screen.getByRole("link", {
       name: "회원가입",
     }) as HTMLAnchorElement;
+
     expect(signupLink).toHaveAttribute("href", "/signup");
   });
 
@@ -57,6 +62,7 @@ describe("로그인 컴포넌트 레이아웃", () => {
     const findPasswordLink = screen.getByRole("link", {
       name: "비밀번호를 잊으셨나요?",
     }) as HTMLAnchorElement;
+
     expect(findPasswordLink).toHaveAttribute("href", "/findpassword");
   });
 });
@@ -65,13 +71,12 @@ describe("로그인 컴포넌트 form 정합성 체크", () => {
   it(`사용자가 이메일을 입력하지 않고 로그인 버튼을 누르면 '${login.message.EMAIL_REQUIRED_VALIDATION}' 문구가 보여야 한다.`, async () => {
     const loginButton = screen.getByRole("button", { name: "로그인" });
 
-    await waitFor(() => {
-      fireEvent.click(loginButton);
-    });
+    fireEvent.click(loginButton);
 
-    const errorMessage = screen.getByText(
+    const errorMessage = (await screen.findByText(
       login.message.EMAIL_REQUIRED_VALIDATION
-    ) as HTMLParagraphElement;
+    )) as HTMLParagraphElement;
+
     expect(errorMessage).toBeInTheDocument();
   });
 
@@ -80,15 +85,15 @@ describe("로그인 컴포넌트 form 정합성 체크", () => {
       "이메일"
     ) as HTMLInputElement;
 
-    await waitFor(() => {
-      fireEvent.change(emailElement, {
-        target: { value: "abc" },
-      });
+    fireEvent.change(emailElement, {
+      target: { value: "abc" },
     });
+    fireEvent.blur(emailElement);
 
-    const errorMessage = screen.getByText(
+    const errorMessage = (await screen.findByText(
       login.message.EMAIL_FORMAT_VALIDATION
-    ) as HTMLParagraphElement;
+    )) as HTMLParagraphElement;
+
     expect(errorMessage).toBeInTheDocument();
   });
 
@@ -106,19 +111,19 @@ describe("로그인 컴포넌트 form 정합성 체크", () => {
     const errorMessage = screen.queryByText(
       login.message.EMAIL_FORMAT_VALIDATION
     ) as HTMLParagraphElement;
+
     expect(errorMessage).not.toBeInTheDocument();
   });
 
   it(`사용자가 비밀번호를 입력하지 않고 로그인 버튼을 누르면 '${login.message.PASSWORD_REQUIRED_VALIDATION}' 문구가 보여야 한다.`, async () => {
     const loginButton = screen.getByRole("button", { name: "로그인" });
 
-    await waitFor(() => {
-      fireEvent.click(loginButton);
-    });
+    fireEvent.click(loginButton);
 
-    const errorMessage = screen.getByText(
+    const errorMessage = (await screen.findByText(
       login.message.PASSWORD_REQUIRED_VALIDATION
-    ) as HTMLParagraphElement;
+    )) as HTMLParagraphElement;
+
     expect(errorMessage).toBeInTheDocument();
   });
 });

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -1,7 +1,27 @@
+import { useFormik, FormikProps } from "formik";
+import * as Yup from "yup";
 import Login from "./Login";
+import { FormValues } from "./types";
+import { login } from "../../utils/constants";
 
 const LoginContainer = () => {
-  return <Login />;
+  const formik: FormikProps<FormValues> = useFormik<FormValues>({
+    initialValues: { email: "", password: "" },
+    validationSchema: Yup.object({
+      email: Yup.string()
+        .email(login.message.EMAIL_FORMAT_VALIDATION)
+        .required(login.message.EMAIL_REQUIRED_VALIDATION),
+      password: Yup.string().required(
+        login.message.PASSWORD_REQUIRED_VALIDATION
+      ),
+    }),
+    onSubmit: (values) => {
+      // TODO: 추후 API 호출 로직 작성필요
+      console.log(values);
+    },
+  });
+
+  return <Login formik={formik} />;
 };
 
 export default LoginContainer;

--- a/src/components/Login/styles.ts
+++ b/src/components/Login/styles.ts
@@ -6,3 +6,7 @@ export const LoginForm = styled.form`
   display: inline-flex;
   flex-direction: column;
 `;
+
+export const ErrorMessage = styled.p`
+  color: ${({ theme }) => theme.colors?.scarlet};
+`;

--- a/src/components/Login/types.ts
+++ b/src/components/Login/types.ts
@@ -1,0 +1,4 @@
+export interface FormValues {
+  email: string;
+  password: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,7 @@
+export const login = {
+  message: {
+    EMAIL_FORMAT_VALIDATION: "올바른 형태의 이메일을 입력해주세요",
+    EMAIL_REQUIRED_VALIDATION: "이메일을 입력해주세요",
+    PASSWORD_REQUIRED_VALIDATION: "비밀번호를 입력해주세요",
+  },
+} as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
     "sourceMap": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "kakao.maps.d.ts",
-      "jest",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["kakao.maps.d.ts", "jest", "@testing-library/jest-dom"],
+    "lib": ["ES2015", "DOM"]
   }
 }


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

로그인 페이지의 이메일, 비밀번호의 유효성을 체크한다.



## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #27 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

테스트 결과
![image](https://user-images.githubusercontent.com/52060742/144710469-303ca88b-9a2d-45b0-8067-14d89176294d.png)


- [x] 이메일, 비밀번호는 사용자가 필수로 입력해야 한다.
- [x] 이메일의 경우 사용자가 입력한 내용이 이메일의 포맷이 맞는지 확인해야 한다.

## 변경된 내용

> 가능하다면 스크린샷을 첨부해주세요.

![image](https://user-images.githubusercontent.com/52060742/144710403-751a2772-b27d-4c89-b39d-2f6cb1e08127.png)

![image](https://user-images.githubusercontent.com/52060742/144710421-152e1439-8aa0-4dd1-898b-a87e3b743fed.png)

![image](https://user-images.githubusercontent.com/52060742/144710433-1c98a388-6151-4615-9658-329c21dbf87d.png)



- formik, yup 사용하여 유효성 체크
- constants.ts 추가
- tsconfig.json에 lib 추가 (async, await 사용을 위함)

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 지금은 이메일만 입력하여도 비밀번호까지 정합성 체크를 같이 하는데 이 부분은 공식문서를 더 읽어보고 리펙토링 할 예정입니다.
- 테스트할 때 `waitFor`를 사용해서 그런가 시간이 좀 걸리는것 같습니다. (waitFor를 사용하지 않고 change 이벤트를 컨트롤 하려고 하면 formik에서 에러가 발생하더라구요 아직 정확한 원인은 파악하지 못했습니다. 😭 쉽지않네요..)