### PR TITLE
DVT-#67 Input Base 컴포넌트 개발

### DIFF
--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -55,8 +55,13 @@ const theme = {
       INTJ: "#f5e1fa",
     },
   },
+  boxShadows: {
+    primary: `0 2px 5px 1px #363a3c25`,
+  },
 };
 
 export default theme;
 
+export type ColorType = keyof typeof theme.colors;
+export type ShadowType = keyof typeof theme.boxShadows;
 export type ThemeType = typeof theme;

--- a/src/components/MyProfile/MyProfile.tsx
+++ b/src/components/MyProfile/MyProfile.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useRef } from "react";
 import { MapMarker } from "react-kakao-maps-sdk";
 import { common, myProfile } from "../../constants";
+import Input from "../base/Input";
 import {
   Container,
   HiddenInput,
   MyProfileForm,
   ProfileImage,
-  Input,
   Select,
   RowContainer,
   ColumnContainer,
@@ -81,8 +81,8 @@ const MyProfile = ({
           onChange={handleImageChange}
         />
 
-        <HiddenInput
-          type="text"
+        <input
+          type="hidden"
           name="profileImgUrl"
           value={formik.values.profileImgUrl || ""}
           onChange={formik.handleChange}

--- a/src/components/base/Input/index.tsx
+++ b/src/components/base/Input/index.tsx
@@ -1,0 +1,47 @@
+import { StyledInput, CustomStyledInput } from "./styles";
+import { IProps } from "./types";
+
+const Input = ({
+  type,
+  name,
+  value,
+  checked,
+  disabled,
+  required,
+  readOnly,
+  placeholder,
+  autoComplete,
+  customStyle,
+  onChange,
+}: IProps) => {
+  return customStyle ? (
+    <CustomStyledInput
+      type={type}
+      name={name}
+      value={value}
+      checked={checked}
+      disabled={disabled}
+      required={required}
+      readOnly={readOnly}
+      placeholder={placeholder}
+      autoComplete={autoComplete}
+      onChange={onChange}
+      customStyle={customStyle}
+    />
+  ) : (
+    <StyledInput
+      type={type}
+      name={name}
+      value={value}
+      checked={checked}
+      disabled={disabled}
+      required={required}
+      readOnly={readOnly}
+      placeholder={placeholder}
+      autoComplete={autoComplete}
+      onChange={onChange}
+    />
+  );
+};
+
+export default Input;

--- a/src/components/base/Input/styles.ts
+++ b/src/components/base/Input/styles.ts
@@ -1,0 +1,52 @@
+import styled from "@emotion/styled";
+import { IProps } from "./types";
+
+export const StyledInput = styled.input<IProps>`
+  width: 100%;
+  color: ${({ theme }) => theme.colors?.gray800};
+  padding: 16px;
+  border: none;
+  background: ${({ theme }) => theme.colors?.white};
+  border-radius: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 2px 5px 1px ${({ theme }) => `${theme.colors?.gray800}25`};
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors?.gray600};
+  }
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors?.gray300};
+  }
+`;
+
+export const CustomStyledInput = styled(StyledInput)<IProps>`
+  width: ${({ customStyle }) => customStyle.width};
+  color: ${({ customStyle, theme }) => theme.colors[customStyle.color]};
+  padding: ${({ customStyle }) => customStyle.padding};
+  border: ${({ customStyle }) => customStyle.border};
+  background-color: ${({ customStyle, theme }) =>
+    theme.colors[customStyle.backgroundColor]};
+  border-radius: ${({ customStyle }) => customStyle.borderRadius};
+  border-top: ${({ customStyle }) => customStyle.borderTop};
+  box-shadow: ${({ customStyle, theme }) =>
+    theme.boxShadows[customStyle.boxShadow]};
+
+  &:focus {
+    outline: ${({ customStyle }) => customStyle.focusOutline};
+  }
+
+  &::placeholder {
+    color: ${({ customStyle, theme }) =>
+      theme.colors[customStyle.placeholderColor]};
+  }
+
+  &:disabled {
+    background-color: ${({ customStyle, theme }) =>
+      theme.colors[customStyle.disabledBackgroundColor]};
+  }
+`;

--- a/src/components/base/Input/types.ts
+++ b/src/components/base/Input/types.ts
@@ -1,0 +1,30 @@
+import { FormEvent } from "react";
+import { ColorType, ShadowType } from "../../../assets/theme";
+
+export interface CustomStyles {
+  width?: string | number;
+  color?: ColorType;
+  padding?: string;
+  border?: string;
+  backgroundColor?: ColorType;
+  borderRadius?: string | number;
+  borderTop?: string | number;
+  boxShadow?: ShadowType;
+  focusOutline?: string;
+  placeholderColor?: ColorType;
+  disabledBackgroundColor?: ColorType;
+}
+
+export interface IProps {
+  type: "text" | "email" | "password" | "checkbox" | "radio" | "hidden";
+  name: string;
+  value: string | number | readonly string[];
+  checked?: boolean;
+  disabled?: boolean;
+  required?: boolean;
+  readOnly?: boolean;
+  placeholder?: string;
+  autoComplete?: string;
+  customStyle?: CustomStyles;
+  onChange?: (event: FormEvent<HTMLInputElement>) => void;
+}


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

Input Base 컴포넌트 개발

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #67 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] Input Base 컴포넌트 개발

## 변경된 내용

> 가능하다면 스크린샷을 첨부해주세요.

없음

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- customStyle 속성을 사용해서 자유롭게 디자인 할 수 있게 구조를 잡아봤는데 코드가가 깔끔하지 않은 느낌이 듭니다.. 더 좋은 방법이 분명 있을 것 같은데 지금은 생각이 안나는 것 같습니다. 어떤식으로 해야 더 깔끔할지 여러분들의 자문을 구하고 싶네요 ㅠㅠㅠ 코드가 너무 마음에 들지 않습니다

```tsx
import { StyledInput, CustomStyledInput } from "./styles";
import { IProps } from "./types";

const Input = ({
  type,
  name,
  value,
  checked,
  disabled,
  required,
  readOnly,
  placeholder,
  autoComplete,
  customStyle,
  onChange,
}: IProps) => {
  // 1. type부터 시작해서 onChange 까지 props들을 CustomStyledInput, StyledInput 둘다 선언하는게 너무 지저분한거 같아요...
  return customStyle ? (
    <CustomStyledInput
      type={type}
      name={name}
      value={value}
      checked={checked}
      disabled={disabled}
      required={required}
      readOnly={readOnly}
      placeholder={placeholder}
      autoComplete={autoComplete}
      onChange={onChange}
      customStyle={customStyle}
    />
  ) : (
    <StyledInput
      type={type}
      name={name}
      value={value}
      checked={checked}
      disabled={disabled}
      required={required}
      readOnly={readOnly}
      placeholder={placeholder}
      autoComplete={autoComplete}
      onChange={onChange}
    />
  );
};

export default Input;
```

원래는 StyledInput 컴포넌트 안에서 customStyle 값에 따라 조건문을 사용하여 구분하려 했지만 이 방법으로 하면 StyledInput 컴포넌트의 내부가 너무 지저분 해져서 customStyle 존재유무에 따라 CustomStyledInput, StyledInput를 분리하게 되었습니다.


> 사용 방법

```tsx
<Input
  type="text"
  name="summary"
  onChange={formik.handleChange}
  value={formik.values.summary || ""}
  customStyle={{ backgroundColor: "orange800", borderRadius: "20px" }}
/>
```

위 코드와 같이 Input 컴포넌트에 별도의 스타일을 입히고 싶을 경우 `customStyle` 에 제가 정의해놓은 타입에 맞게 설정해주시면 됩니다. 만약 customStyle 속성을 사용하지 않으면 제가 기본으로 만들어 놓은 
![image](https://user-images.githubusercontent.com/52060742/145681980-4c3ef03a-7e39-4648-a76b-9bfae8bf458f.png)
이러한 형태의 Input이 됩니다. 

또한 다른 css 속성이 필요하다면 자유롭게 추가하시면 됩니다!
