### PR TITLE
DVT-#85 데둥이 소개 페이지 리스트 레이아웃

### DIFF
--- a/fixtures/selectDatas.ts
+++ b/fixtures/selectDatas.ts
@@ -1,0 +1,21 @@
+interface SelectOption {
+  value: string | number;
+  label: string;
+}
+
+export const courses: SelectOption[] = [
+  { value: "FE", label: "프론트엔드" },
+  { value: "BE", label: "백엔드" },
+  { value: "AI", label: "인공지능" },
+];
+
+export const generations: SelectOption[] = [
+  { value: "1", label: "1기" },
+  { value: "2", label: "2기" },
+];
+
+export const roles: SelectOption[] = [
+  { value: "STUDENT", label: "수강생" },
+  { value: "MANAGER", label: "매니저" },
+  { value: "MENTOR", label: "멘토" },
+];

--- a/fixtures/userList.ts
+++ b/fixtures/userList.ts
@@ -1,0 +1,45 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as faker from "faker";
+import { User } from "../src/components/UserList/types";
+import {
+  course,
+  role,
+  CourseKeyType,
+  MbtiKeyType,
+  RoleKeyType,
+} from "../src/constants";
+
+const random = <Type>(array: Type[]): Type => {
+  const randomIndex = Math.floor(Math.random() * array.length);
+
+  return array[randomIndex];
+};
+
+const mbti = () => {
+  return (
+    random(["E", "I"]) +
+    random(["N", "S"]) +
+    random(["F", "T"]) +
+    random(["J", "P"])
+  );
+};
+
+const randomUsers = (): User => ({
+  user: {
+    userId: faker.datatype.number(),
+    name: faker.name.firstName(),
+    course: random<CourseKeyType>(Object.keys(course) as CourseKeyType[]),
+    generation: Math.floor(Math.random() * 100),
+    role: random<RoleKeyType>(Object.keys(role) as RoleKeyType[]),
+  },
+  introduction: {
+    introductionId: faker.datatype.number(),
+    profileImgUrl: faker.image.imageUrl(),
+    mbti: mbti() as MbtiKeyType,
+    summary: faker.lorem.sentence(),
+    likeCount: faker.datatype.number(),
+    commentCount: faker.datatype.number(),
+  },
+});
+
+export default randomUsers;

--- a/src/assets/media.ts
+++ b/src/assets/media.ts
@@ -4,3 +4,10 @@ export const breakpoints = {
   maxTablet: "@media screen and (max-width: 1229px)",
   minDesktop: "@media screen and (min-width: 1230px)",
 };
+
+export const MediaQueriesBreakpoints = {
+  mobile: "@media screen and (min-width: 576px)",
+  tablet: "@media screen and (min-width: 768px)",
+  desktop: "@media screen and (min-width: 992px)",
+  largeDesktop: "@media screen and (min-width: 1200px)",
+};

--- a/src/assets/media.ts
+++ b/src/assets/media.ts
@@ -5,7 +5,7 @@ export const breakpoints = {
   minDesktop: "@media screen and (min-width: 1230px)",
 };
 
-export const MediaQueriesBreakpoints = {
+export const mediaQueriesBreakpoints = {
   mobile: "@media screen and (min-width: 576px)",
   tablet: "@media screen and (min-width: 768px)",
   desktop: "@media screen and (min-width: 992px)",

--- a/src/components/CommentButton/CommentButton.tsx
+++ b/src/components/CommentButton/CommentButton.tsx
@@ -6,9 +6,7 @@ interface Props {
 }
 
 const CommentButton = ({ onClick }: Props) => {
-  const icon = (
-    <BiComment style={{ verticalAlign: "text-top" }} data-testid="filled" />
-  );
+  const icon = <BiComment data-testid="filled" />;
 
   return (
     <Button name="comment" onClick={onClick}>

--- a/src/components/LikeButton/LikeButton.tsx
+++ b/src/components/LikeButton/LikeButton.tsx
@@ -8,17 +8,9 @@ interface Props {
 
 const LikeButton = ({ isLiked, onClick }: Props) => {
   const icon = isLiked ? (
-    <BsSuitHeartFill
-      style={{ verticalAlign: "text-top" }}
-      color="red"
-      data-testid="filled"
-    />
+    <BsSuitHeartFill color="red" data-testid="filled" />
   ) : (
-    <BsSuitHeart
-      style={{ verticalAlign: "text-top" }}
-      color="red"
-      data-testid="empty"
-    />
+    <BsSuitHeart color="red" data-testid="empty" />
   );
 
   return (

--- a/src/components/MyProfile/MyProfile.tsx
+++ b/src/components/MyProfile/MyProfile.tsx
@@ -47,7 +47,7 @@ const mbtis: string[] = [
   "ENTP",
   "ESTJ",
   "ESFJ",
-  "ENFA",
+  "ENFJ",
   "ENFP",
   "ESTP",
   "ESFP",

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -102,10 +102,14 @@ const ProfileCard = ({ user }: IProps) => {
         <LikeButtonAndText
           isLiked
           likeCount={user.introduction.likeCount}
+          // TODO: API 연동 필요
+          // eslint-disable-next-line
           onClick={() => console.log("like!")}
         />
         <CommentButtonAndText
           commentCount={user.introduction.commentCount}
+          // TODO: API 연동 필요
+          // eslint-disable-next-line
           onClick={() => console.log("comment!")}
         />
       </LikeAndCommentContainer>

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -1,0 +1,134 @@
+import styled from "@emotion/styled";
+import { common } from "../../constants";
+import Image from "../base/Image";
+import Text from "../base/Text";
+import CommentButtonAndText from "../CommentButtonAndText/CommentButtonAndText";
+import LikeButtonAndText from "../LikeButtonAndText/LikeButtonAndText";
+import { User } from "../UserList/types";
+
+interface IProps {
+  user: User;
+}
+
+const colorMap = {
+  FE: "primary",
+  BE: "ultramarine",
+  AI: "scarlet",
+};
+
+const Container = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 240px;
+  height: 100%;
+  justify-self: center;
+  border-radius: 12px;
+  box-shadow: ${({ theme }) => theme.boxShadows.primary};
+  cursor: pointer;
+  overflow: hidden;
+
+  &:hover {
+    transform: scale(1.1);
+    transition: transform 0.5s;
+  }
+`;
+
+const ImageWrapper = styled.div`
+  flex-grow: 1;
+  height: 216px;
+  border-radius: 12px 12px 0 0;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 36px;
+  padding: 0 8px;
+  margin: 16px 0;
+`;
+
+const DescriptionContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  height: 50px;
+`;
+
+const DescriptionWrapper = styled.div<{ course: string }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  justify-self: center;
+  background-color: ${({ theme, course }) => theme.colors[colorMap[course]]};
+  border-right: 1px solid ${({ theme }) => theme.colors.white};
+  overflow: hidden;
+
+  &:last-child {
+    border-right: 0;
+  }
+`;
+
+const LikeAndCommentContainer = styled.div`
+  display: flex;
+  padding: 0 8px;
+  gap: 0 8px;
+  margin-bottom: 8px;
+`;
+
+const ProfileCard = ({ user }: IProps) => {
+  return (
+    <Container>
+      <ImageWrapper>
+        <Image
+          src={user.introduction.profileImgUrl || common.placeHolderImageSrc}
+          width="100%"
+          height="100%"
+          mode="cover"
+          alt="유저 섬네일 이미지"
+        />
+      </ImageWrapper>
+
+      <TextContainer>
+        <Text size={16} strong ellipsisLineClamp={2}>
+          {user.introduction.summary}
+        </Text>
+      </TextContainer>
+
+      <LikeAndCommentContainer>
+        <LikeButtonAndText
+          isLiked
+          likeCount={user.introduction.likeCount}
+          onClick={() => console.log("like!")}
+        />
+        <CommentButtonAndText
+          commentCount={user.introduction.commentCount}
+          onClick={() => console.log("comment!")}
+        />
+      </LikeAndCommentContainer>
+
+      <DescriptionContainer>
+        <DescriptionWrapper course={user.user.course}>
+          <Text size={14} color="white" strong ellipsisLineClamp={1}>
+            {user.user.course}
+          </Text>
+        </DescriptionWrapper>
+        <DescriptionWrapper course={user.user.course}>
+          <Text size={14} color="white" strong ellipsisLineClamp={1}>
+            {user.user.name}
+          </Text>
+        </DescriptionWrapper>
+        <DescriptionWrapper course={user.user.course}>
+          <Text size={14} color="white" strong ellipsisLineClamp={1}>
+            {`${user.user.generation}기`}
+          </Text>
+        </DescriptionWrapper>
+      </DescriptionContainer>
+    </Container>
+  );
+};
+
+export default ProfileCard;

--- a/src/components/UserCard/styles.ts
+++ b/src/components/UserCard/styles.ts
@@ -5,6 +5,7 @@ export const Container = styled.div`
   flex-direction: column;
   gap: 10px;
   width: 220px;
+  padding-bottom: 8px;
   cursor: pointer;
   transition: background-color 0.2s ease;
   overflow-x: hidden;

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,0 +1,112 @@
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { courses, generations, roles } from "../../../fixtures/selectDatas";
+import { common } from "../../constants";
+import Input from "../base/Input";
+import Text from "../base/Text";
+import ProfileCard from "../ProfileCard/ProfileCard";
+import {
+  Button,
+  Container,
+  SearchBarFormContainer,
+  UserContainer,
+  InputWrapper,
+  ButtonWrapper,
+  Select,
+} from "./styles";
+import { IProps } from "./types";
+
+const UserList = ({ users }: IProps) => {
+  const { handleChange, handleSubmit, handleBlur, values } = useFormik<{
+    name: string;
+    course: string;
+    generation: string;
+    role: string;
+  }>({
+    initialValues: { name: "", course: "", generation: "", role: "" },
+    validationSchema: Yup.string().required("zz"),
+    onSubmit: (formValues, { setSubmitting }) => {
+      setSubmitting(true);
+      // TODO: 백엔드 API 개발되면 붙여야 함
+      // eslint-disable-next-line
+      console.log(formValues);
+      setSubmitting(false);
+    },
+  });
+
+  return (
+    <Container>
+      <SearchBarFormContainer onSubmit={handleSubmit}>
+        <InputWrapper>
+          <Select
+            id="generation"
+            name="generation"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.generation}
+          >
+            <option value="">{common.text.GENERATION}</option>
+            {generations.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Select>
+          <Select
+            id="course"
+            name="course"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.course}
+          >
+            <option value="">{common.text.COURSE}</option>
+            {courses.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Select>
+          <Select
+            id="role"
+            name="role"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.role}
+          >
+            <option value="">{common.text.ROLE}</option>
+            {roles.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </Select>
+          <Input
+            type="text"
+            name="name"
+            placeholder={common.message.ENTER_SEARCH_TERM}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.name}
+          />
+        </InputWrapper>
+
+        <ButtonWrapper>
+          <Button type="submit">
+            <Text size={12} color="white" strong ellipsisLineClamp={1}>
+              {common.text.SEARCH}
+            </Text>
+          </Button>
+        </ButtonWrapper>
+      </SearchBarFormContainer>
+
+      <UserContainer>
+        {/* TODO: 검색 결과가 없을 경우 */}
+        {users.map((user) => (
+          <ProfileCard key={user.user.userId} user={user} />
+        ))}
+      </UserContainer>
+    </Container>
+  );
+};
+
+export default UserList;

--- a/src/components/UserList/UserListContainer.tsx
+++ b/src/components/UserList/UserListContainer.tsx
@@ -1,0 +1,11 @@
+import randomUsers from "../../../fixtures/userList";
+import UserList from "./UserList";
+
+const UserListContainer = () => {
+  // TODO: 모킹 데이터이므로 API 연동이 완료되면 API 데이터로 교체한다.
+  const users = Array.from({ length: 10 }, () => randomUsers());
+
+  return <UserList users={users} />;
+};
+
+export default UserListContainer;

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -30,7 +30,7 @@ export const UserContainer = styled.div`
     grid-template-columns: repeat(6, 1fr);
   }
 
-  grid-auto-rows: 350px;
+  grid-auto-rows: 360px;
   justify-content: center;
   align-items: center;
 `;

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -1,0 +1,86 @@
+import styled from "@emotion/styled";
+import { MediaQueriesBreakpoints } from "../../assets/media";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  overflow-y: auto;
+`;
+
+export const UserContainer = styled.div`
+  display: grid;
+  gap: 32px;
+
+  ${MediaQueriesBreakpoints.mobile} {
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  ${MediaQueriesBreakpoints.tablet} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  ${MediaQueriesBreakpoints.desktop} {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  ${MediaQueriesBreakpoints.largeDesktop} {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  grid-auto-rows: 350px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const SearchBarFormContainer = styled.form`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 32px;
+  gap: 0 16px;
+`;
+
+export const Select = styled.select`
+  width: 15%;
+  min-width: 64px;
+  color: ${({ theme }) => theme.colors?.gray800};
+  padding: 16px;
+  border: none;
+  background: ${({ theme }) => theme.colors?.white};
+  border-radius: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: ${({ theme }) => theme.boxShadows.primary};
+  -o-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  outline: none;
+`;
+
+export const Button = styled.button`
+  min-width: 64px;
+  margin-top: auto;
+  padding: 16px 16px;
+  border: none;
+  background: ${({ theme }) => theme.colors?.primary};
+  border-radius: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  color: ${({ theme }) => theme.colors?.gray800};
+  box-shadow: ${({ theme }) => theme.boxShadows.primary};
+  flex-grow: 1;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  width: 90%;
+  gap: 0 8px;
+  align-items: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  width: 10%;
+`;

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { MediaQueriesBreakpoints } from "../../assets/media";
+import { mediaQueriesBreakpoints } from "../../assets/media";
 
 export const Container = styled.div`
   display: flex;
@@ -14,19 +14,19 @@ export const UserContainer = styled.div`
   display: grid;
   gap: 32px;
 
-  ${MediaQueriesBreakpoints.mobile} {
+  ${mediaQueriesBreakpoints.mobile} {
     grid-template-columns: repeat(1, 1fr);
   }
 
-  ${MediaQueriesBreakpoints.tablet} {
+  ${mediaQueriesBreakpoints.tablet} {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  ${MediaQueriesBreakpoints.desktop} {
+  ${mediaQueriesBreakpoints.desktop} {
     grid-template-columns: repeat(4, 1fr);
   }
 
-  ${MediaQueriesBreakpoints.largeDesktop} {
+  ${mediaQueriesBreakpoints.largeDesktop} {
     grid-template-columns: repeat(6, 1fr);
   }
 

--- a/src/components/UserList/types.ts
+++ b/src/components/UserList/types.ts
@@ -1,0 +1,22 @@
+export interface User {
+  user: {
+    userId: number;
+    name: string;
+    course: string;
+    generation: number;
+    role: string;
+  };
+
+  introduction: {
+    introductionId: number;
+    profileImgUrl: string | null;
+    mbti: string | null;
+    summary: string | null;
+    likeCount: number;
+    commentCount: number;
+  };
+}
+
+export interface IProps {
+  users: User[];
+}

--- a/src/components/base/Button/styles.ts
+++ b/src/components/base/Button/styles.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 
 export const StyledButton = styled.button`
+  display: flex;
   background-color: transparent;
   border: 0;
   outline: 0;

--- a/src/components/base/Input/index.tsx
+++ b/src/components/base/Input/index.tsx
@@ -13,6 +13,7 @@ const Input = ({
   autoComplete,
   customStyle,
   onChange,
+  onBlur,
 }: IProps) => {
   return customStyle ? (
     <CustomStyledInput
@@ -26,6 +27,7 @@ const Input = ({
       placeholder={placeholder}
       autoComplete={autoComplete}
       onChange={onChange}
+      onBlur={onBlur}
       customStyle={customStyle}
     />
   ) : (
@@ -39,6 +41,7 @@ const Input = ({
       readOnly={readOnly}
       placeholder={placeholder}
       autoComplete={autoComplete}
+      onBlur={onBlur}
       onChange={onChange}
     />
   );

--- a/src/components/base/Input/types.ts
+++ b/src/components/base/Input/types.ts
@@ -1,4 +1,4 @@
-import { FormEvent } from "react";
+import { FocusEvent, FormEvent } from "react";
 import { ColorType, ShadowType } from "../../../assets/theme";
 
 export interface CustomStyles {
@@ -27,4 +27,5 @@ export interface IProps {
   autoComplete?: string;
   customStyle?: CustomStyles;
   onChange?: (event: FormEvent<HTMLInputElement>) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -5,6 +5,7 @@ export default {
     EMAIL: "이메일",
     GENERATION: "기수",
     COURSE: "코스",
+    ROLE: "역할",
     PASSWORD: "비밀번호",
     CONFIRM_PASSWORD: "비밀번호 확인",
     MBTI: "MBTI",
@@ -12,6 +13,11 @@ export default {
     BLOG: "블로그",
     SUMMARY: "한줄 소개",
     DESCRIPTION: "자기 소개",
+    SEARCH: "검색",
+  },
+
+  message: {
+    ENTER_SEARCH_TERM: "검색어를 입력해 주세요",
   },
 
   buttonName: {
@@ -19,4 +25,7 @@ export default {
   },
 
   defaultPosition: { lat: 37.4921180264813, lng: 127.0300023501 },
+
+  placeHolderImageSrc:
+    "https://upload.wikimedia.org/wikipedia/commons/8/89/Portrait_Placeholder.png",
 };

--- a/src/pages/UserListPage/index.tsx
+++ b/src/pages/UserListPage/index.tsx
@@ -1,0 +1,7 @@
+import UserListContainer from "../../components/UserList/UserListContainer";
+
+const UserListPage = () => {
+  return <UserListContainer />;
+};
+
+export default UserListPage;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,6 +9,8 @@ import GatherPage from "../pages/GatherPage";
 import GatherClubPage from "../pages/GatherClubPage";
 import GatherProjectPage from "../pages/GatherProjectPage";
 import GatherStudyPage from "../pages/GatherStudyPage";
+import { PrivateRoute } from "./customRoutes";
+import UserListPage from "../pages/UserListPage";
 
 const Router = () => {
   return (
@@ -17,8 +19,18 @@ const Router = () => {
       <Route path={routes.SIGNUP} exact component={SignupPage} />
       <Route path={routes.LOGIN} exact component={LoginPage} />
       <Route path={routes.ADMIN} exact component={MainPage} />
-      <Route path={routes.MYPROFILE} exact component={MyProfilePage} />
-      <Route path={routes.USERLIST} exact component={MainPage} />
+      <PrivateRoute
+        path={routes.MYPROFILE}
+        fallbackPath="/login"
+        exact
+        component={MyProfilePage}
+      />
+      <PrivateRoute
+        path={routes.USERLIST}
+        fallbackPath="/login"
+        exact
+        component={UserListPage}
+      />
       <Route path={routes.USERLIST_ID} exact component={MainPage} />
       <Route path={routes.MYGATHERLIST} exact component={MainPage} />
       <Route path={routes.GATHERLIST} exact component={GatherPage} />

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,13 +21,13 @@ const Router = () => {
       <Route path={routes.ADMIN} exact component={MainPage} />
       <PrivateRoute
         path={routes.MYPROFILE}
-        fallbackPath="/login"
+        fallbackPath={routes.LOGIN}
         exact
         component={MyProfilePage}
       />
       <PrivateRoute
         path={routes.USERLIST}
-        fallbackPath="/login"
+        fallbackPath={routes.LOGIN}
         exact
         component={UserListPage}
       />

--- a/src/routes/customRoutes/PrivateRoute.tsx
+++ b/src/routes/customRoutes/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 import { ComponentType } from "react";
 import { Route, Redirect } from "react-router-dom";
 import { login } from "../../constants";
-import { getLocalStorageItem } from "../../utils/functions";
+import { useLocalStorage } from "../../hooks";
 
 interface IProps {
   path: string;
@@ -19,13 +19,13 @@ const PrivateRoute = ({
   fallbackPath,
   ...rest
 }: IProps) => {
-  const isLogin = getLocalStorageItem(login.localStorageKey.TOKEN, null);
+  const [token] = useLocalStorage(login.localStorageKey.TOKEN, null);
 
   return (
     <Route
       {...rest}
       render={(props) =>
-        isLogin ? <Component {...props} /> : <Redirect to={fallbackPath} />
+        token ? <Component {...props} /> : <Redirect to={fallbackPath} />
       }
     />
   );


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #85 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 데둥이 소개 페이지 레이아웃 구성
- [x] 반응형 적용


## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

움짤 자꾸 용량초과돼서 사진을 임시로 올리겠습니다

![image](https://user-images.githubusercontent.com/52060742/145932750-1d1a1a75-bf17-4827-85df-47e875222194.png)

![image](https://user-images.githubusercontent.com/52060742/145933240-f95e3b8c-7d26-49f7-b649-d794e3d01123.png)


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 백엔드 API가 구성되지 않아 레이아웃 작업 진행
- `MBTI`는 표시하지 않았습니다. 카드에 너무 많은 정보가 있으면 난잡(?) 해지는 것 같아요 ㅠㅠ
- `(메인화면)` 부분은 @datalater 의 확인이 필요합니다 🙏
- (메인화면) base/Button에 `display: flex` 추가 -> 정렬을 위함
- (메인화면) CommentButton, LiknkButton -> `verticalAlgin: text-top` 제거 -> 정렬을 위함
- (메인화면) UserCard -> `padding-bottom` 추가 (위 변경사항에 대해 스크롤이 생겨 padding 값을 줌)
- MBTI 데이터 수정
- breakpoints 추가 (팀원간 협의 후 사용) -> max, min 둘 중 하나로 통일해서 사용하는 게 좋을 것 같습니다. 기준은 [여기](https://devfacts.com/media-queries-breakpoints-2021)를 참조했습니다.
```ts
// 기존
export const breakpoints = {
  maxMobile: "@media screen and (max-width: 599px)",
  minTablet: "@media screen and (min-width: 600px)",
  maxTablet: "@media screen and (max-width: 1229px)",
  minDesktop: "@media screen and (min-width: 1230px)",
};

// 새로 추가
export const mediaQueriesBreakpoints = {
  mobile: "@media screen and (min-width: 576px)",
  tablet: "@media screen and (min-width: 768px)",
  desktop: "@media screen and (min-width: 992px)",
  largeDesktop: "@media screen and (min-width: 1200px)",
};

  ```
