### PR TITLE
DVT-#105 데둥이 소개 무한스크롤

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
+    "react-intersection-observer": "^8.33.1",
     "react-kakao-maps-sdk": "^1.0.4",
     "react-lottie": "^1.2.3",
     "react-markdown": "^7.1.1",

--- a/src/assets/media.ts
+++ b/src/assets/media.ts
@@ -9,5 +9,6 @@ export const mediaQueriesBreakpoints = {
   mobile: "@media screen and (min-width: 576px)",
   tablet: "@media screen and (min-width: 768px)",
   desktop: "@media screen and (min-width: 992px)",
-  largeDesktop: "@media screen and (min-width: 1200px)",
+  middleDesktop: "@media screen and (min-width: 1200px)",
+  largeDesktop: "@media screen and (min-width: 1600px)",
 };

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -1,6 +1,7 @@
 import { useFormik, FormikProps } from "formik";
 import { useHistory } from "react-router-dom";
 import { useMutation } from "react-query";
+import { useSetRecoilState } from "recoil";
 import { FormValues } from "./types";
 import { requestLogin } from "../../utils/apis";
 import { loginValidator } from "../../utils/yups/login";
@@ -8,7 +9,6 @@ import { MutationData, MutationError } from "../../types/commonTypes";
 import { login, errorCode } from "../../constants";
 import Login from "./Login";
 import { useLocalStorage } from "../../hooks";
-import { useSetRecoilState } from "recoil";
 import { authState } from "../../atoms/auth";
 
 const LoginContainer = () => {

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -8,15 +8,19 @@ import { MutationData, MutationError } from "../../types/commonTypes";
 import { login, errorCode } from "../../constants";
 import Login from "./Login";
 import { useLocalStorage } from "../../hooks";
+import { useSetRecoilState } from "recoil";
+import { authState } from "../../atoms/auth";
 
 const LoginContainer = () => {
   const history = useHistory();
+  const setAuthState = useSetRecoilState(authState);
   const [, setToken] = useLocalStorage(login.localStorageKey.TOKEN, "");
   const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
     (values: FormValues) => requestLogin(values),
     {
       onSuccess: ({ data }) => {
         setToken(data.data.token);
+        setAuthState(data.data.token);
         history.push("/");
       },
       onError: ({ response }) => {

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -54,9 +54,7 @@ const ProfileCard = ({ user }: IProps) => {
         <LikeButtonAndText
           isLiked
           likeCount={user.introduction.likeCount}
-          // TODO: API 연동 필요
-          // eslint-disable-next-line
-          onClick={() => console.log("like!")}
+          onClick={handleClick(user?.introduction.introductionId)}
         />
         <CommentButtonAndText
           commentCount={user.introduction.commentCount}

--- a/src/components/UserDetail/Comment/index.tsx
+++ b/src/components/UserDetail/Comment/index.tsx
@@ -176,31 +176,6 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
             </>
           )}
         </ButtonContainer>
-
-        {/* {myProfile.user.userId === comment.writer.userId &&
-          comment.status !== common.commentStatus.DELETED && (
-            <ButtonContainer>
-              {!isChild && (
-                <IconButton role="button" onClick={handleChildCommentClick}>
-                  <FaComments size={24} />
-                </IconButton>
-              )}
-
-              <IconButton role="button" onClick={handleModifyClick}>
-                <BsFillKeyboardFill size={24} />
-              </IconButton>
-
-              <IconButton
-                role="button"
-                onClick={handleDeleteClick(comment.commentId)}
-              >
-                <MdDeleteSweep size={24} />
-              </IconButton>
-            </ButtonContainer>
-
-
-
-          )} */}
       </CommentContainer>
 
       {isChildCommentClick && (

--- a/src/components/UserDetail/Comment/index.tsx
+++ b/src/components/UserDetail/Comment/index.tsx
@@ -151,7 +151,33 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
           )}
         </ContentContainer>
 
-        {myProfile.user.userId === comment.writer.userId &&
+        <ButtonContainer>
+          {comment.status !== common.commentStatus.DELETED && (
+            <>
+              {!isChild && (
+                <IconButton role="button" onClick={handleChildCommentClick}>
+                  <FaComments size={24} />
+                </IconButton>
+              )}
+
+              {myProfile.user.userId === comment.writer.userId && (
+                <>
+                  <IconButton role="button" onClick={handleModifyClick}>
+                    <BsFillKeyboardFill size={24} />
+                  </IconButton>
+                  <IconButton
+                    role="button"
+                    onClick={handleDeleteClick(comment.commentId)}
+                  >
+                    <MdDeleteSweep size={24} />
+                  </IconButton>{" "}
+                </>
+              )}
+            </>
+          )}
+        </ButtonContainer>
+
+        {/* {myProfile.user.userId === comment.writer.userId &&
           comment.status !== common.commentStatus.DELETED && (
             <ButtonContainer>
               {!isChild && (
@@ -171,7 +197,10 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
                 <MdDeleteSweep size={24} />
               </IconButton>
             </ButtonContainer>
-          )}
+
+
+
+          )} */}
       </CommentContainer>
 
       {isChildCommentClick && (

--- a/src/components/UserDetail/Comment/styles.ts
+++ b/src/components/UserDetail/Comment/styles.ts
@@ -25,7 +25,6 @@ export const ImageWrapper = styled.div`
   border-radius: 50%;
   overflow: hidden;
   margin-right: 8px;
-  cursor: pointer;
   flex-grow: 0;
 `;
 

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,11 +1,13 @@
 import { useFormik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import * as Yup from "yup";
+import { useInView } from "react-intersection-observer";
 import { courses, generations, roles } from "../../../fixtures/selectDatas";
 import { common } from "../../constants";
 import Input from "../base/Input";
 import Text from "../base/Text";
 import ProfileCard from "../ProfileCard/ProfileCard";
+
 import {
   Button,
   Container,
@@ -15,6 +17,7 @@ import {
   ButtonWrapper,
   Select,
   ProfileCardWrapper,
+  NotFoundResult,
 } from "./styles";
 import { IProps } from "./types";
 
@@ -36,15 +39,25 @@ const UserList = ({
     onSubmit: (formValues, { setSubmitting }) => {
       setSubmitting(true);
       // nextLastId에 null을 넣은 이유는 무한스크롤 외 일반 조회할 때는 필요없기 때문
-      setFilters({ ...formValues, nextLastId: null, size: 15 });
+      setFilters({
+        ...formValues,
+        nextLastId: null,
+        size: common.userListInfinitePageCount,
+      });
       setSubmitting(false);
     },
   });
 
-  console.log(fetchNextPage, hasNextPage);
+  const [ref, inView] = useInView({ threshold: 0.8 });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isLoading) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, inView, hasNextPage, isLoading]);
 
   return (
-    <Container>
+    <Container id="container">
       <SearchBarFormContainer onSubmit={handleSubmit}>
         <InputWrapper>
           <Select
@@ -109,24 +122,29 @@ const UserList = ({
       </SearchBarFormContainer>
 
       {/* TODO: 검색 결과가 없을 경우 */}
+      {pages?.pages[0].data.data.values.length === 0 && (
+        <NotFoundResult>
+          <Text size={32} strong>
+            해당 이름을 가진 사용자는 없네요 😥
+          </Text>
+        </NotFoundResult>
+      )}
       {!isLoading && (
         <UserContainer>
           {pages?.pages.map((page, pageIndex) => (
             // eslint-disable-next-line
             <React.Fragment key={`${page}/${pageIndex}`}>
               {page.data.data.values.map((user) => (
-                <ProfileCardWrapper key={user.user.userId} role="feed">
+                <ProfileCardWrapper
+                  key={user.user.userId}
+                  role="feed"
+                  ref={ref}
+                >
                   <ProfileCard user={user} />
                 </ProfileCardWrapper>
               ))}
             </React.Fragment>
           ))}
-
-          {/* {pages?.values.map((user) => (
-            <ProfileCardWrapper key={user.user.userId} role="feed">
-              <ProfileCard user={user} />
-            </ProfileCardWrapper>
-          ))} */}
         </UserContainer>
       )}
     </Container>

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -30,7 +30,7 @@ const UserList = ({ users, setFilters, isLoading }: IProps) => {
       setSubmitting(true);
       // TODO: 백엔드 API 개발되면 붙여야 함
       // eslint-disable-next-line
-      setFilters({ ...formValues, nextLastId: users?.nextLastId, size: 5 });
+      setFilters({ ...formValues, nextLastId: users?.nextLastId, size: 20 });
       setSubmitting(false);
     },
   });

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -57,7 +57,7 @@ const UserList = ({
   }, [fetchNextPage, inView, hasNextPage, isLoading]);
 
   return (
-    <Container id="container">
+    <Container>
       <SearchBarFormContainer onSubmit={handleSubmit}>
         <InputWrapper>
           <Select

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,4 +1,5 @@
 import { useFormik } from "formik";
+import React from "react";
 import * as Yup from "yup";
 import { courses, generations, roles } from "../../../fixtures/selectDatas";
 import { common } from "../../constants";
@@ -17,7 +18,13 @@ import {
 } from "./styles";
 import { IProps } from "./types";
 
-const UserList = ({ users, setFilters, isLoading }: IProps) => {
+const UserList = ({
+  pages,
+  setFilters,
+  isLoading,
+  fetchNextPage,
+  hasNextPage,
+}: IProps) => {
   const { handleChange, handleSubmit, handleBlur, values } = useFormik<{
     name: string;
     course: string;
@@ -28,12 +35,13 @@ const UserList = ({ users, setFilters, isLoading }: IProps) => {
     validationSchema: Yup.string().required(""),
     onSubmit: (formValues, { setSubmitting }) => {
       setSubmitting(true);
-      // TODO: 백엔드 API 개발되면 붙여야 함
-      // eslint-disable-next-line
-      setFilters({ ...formValues, nextLastId: users?.nextLastId, size: 20 });
+      // nextLastId에 null을 넣은 이유는 무한스크롤 외 일반 조회할 때는 필요없기 때문
+      setFilters({ ...formValues, nextLastId: null, size: 15 });
       setSubmitting(false);
     },
   });
+
+  console.log(fetchNextPage, hasNextPage);
 
   return (
     <Container>
@@ -103,11 +111,22 @@ const UserList = ({ users, setFilters, isLoading }: IProps) => {
       {/* TODO: 검색 결과가 없을 경우 */}
       {!isLoading && (
         <UserContainer>
-          {users?.values.map((user) => (
+          {pages?.pages.map((page, pageIndex) => (
+            // eslint-disable-next-line
+            <React.Fragment key={`${page}/${pageIndex}`}>
+              {page.data.data.values.map((user) => (
+                <ProfileCardWrapper key={user.user.userId} role="feed">
+                  <ProfileCard user={user} />
+                </ProfileCardWrapper>
+              ))}
+            </React.Fragment>
+          ))}
+
+          {/* {pages?.values.map((user) => (
             <ProfileCardWrapper key={user.user.userId} role="feed">
               <ProfileCard user={user} />
             </ProfileCardWrapper>
-          ))}
+          ))} */}
         </UserContainer>
       )}
     </Container>

--- a/src/components/UserList/UserListContainer.tsx
+++ b/src/components/UserList/UserListContainer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { routes } from "../../constants";
-import useFilteredUserList from "../../hooks/useFilteredUserList";
+import useUserInfiniteQuery from "../../hooks/useUserInfiniteQuery";
 import { Filters } from "./types";
 import UserList from "./UserList";
 
@@ -12,12 +12,18 @@ const UserListContainer = () => {
     generation: null,
     role: null,
     nextLastId: null,
-    size: 20,
+    size: 15,
   });
   const history = useHistory();
 
   // TODO: 로딩처리 해야 함
-  const { data: users, isLoading, isError } = useFilteredUserList(filters);
+  const {
+    data: pages,
+    isLoading,
+    isError,
+    hasNextPage,
+    fetchNextPage,
+  } = useUserInfiniteQuery(filters);
 
   useEffect(() => {
     if (isError) {
@@ -28,8 +34,10 @@ const UserListContainer = () => {
   return (
     <UserList
       isLoading={isLoading}
-      users={users?.data.data}
+      pages={pages}
       setFilters={setFilters}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
     />
   );
 };

--- a/src/components/UserList/UserListContainer.tsx
+++ b/src/components/UserList/UserListContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { routes } from "../../constants";
+import { common, routes } from "../../constants";
 import useUserInfiniteQuery from "../../hooks/useUserInfiniteQuery";
 import { Filters } from "./types";
 import UserList from "./UserList";
@@ -12,7 +12,7 @@ const UserListContainer = () => {
     generation: null,
     role: null,
     nextLastId: null,
-    size: 15,
+    size: common.userListInfinitePageCount,
   });
   const history = useHistory();
 

--- a/src/components/UserList/UserListContainer.tsx
+++ b/src/components/UserList/UserListContainer.tsx
@@ -12,7 +12,7 @@ const UserListContainer = () => {
     generation: null,
     role: null,
     nextLastId: null,
-    size: 15, // TODO: 무한스크롤 구현할 때 바꿔야 함
+    size: 20,
   });
   const history = useHistory();
 

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -93,3 +93,11 @@ export const ProfileCardWrapper = styled.div`
   display: flex;
   justify-content: center;
 `;
+
+export const NotFoundResult = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -26,6 +26,10 @@ export const UserContainer = styled.div`
     grid-template-columns: repeat(4, 1fr);
   }
 
+  ${mediaQueriesBreakpoints.middleDesktop} {
+    grid-template-columns: repeat(5, 1fr);
+  }
+
   ${mediaQueriesBreakpoints.largeDesktop} {
     grid-template-columns: repeat(6, 1fr);
   }

--- a/src/components/UserList/types.ts
+++ b/src/components/UserList/types.ts
@@ -32,7 +32,9 @@ export interface Filters {
 }
 
 export interface IProps {
-  users: Contents;
+  // TODO: infiniteQuery 관련 타입 어떻게 처리 할 지
+  // eslint-disable-next-line
+  pages: any;
   setFilters: React.Dispatch<
     React.SetStateAction<{
       name: string | null;
@@ -44,4 +46,10 @@ export interface IProps {
     }>
   >;
   isLoading: boolean;
+  // TODO: infiniteQuery 관련 타입 어떻게 처리 할 지
+  // eslint-disable-next-line
+  hasNextPage: any;
+  // TODO: infiniteQuery 관련 타입 어떻게 처리 할 지
+  // eslint-disable-next-line
+  fetchNextPage: any;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -19,7 +19,7 @@ export default {
   },
 
   message: {
-    ENTER_SEARCH_TERM: "검색어를 입력해 주세요",
+    ENTER_SEARCH_TERM: "찾을 이름을 입력해 주세요",
     ENTER_COMMENT: "댓글을 입력해 주세요",
     UNKNOWN_ERROR: "알수없는 오류입니다. 다시 시도해주세요.",
     EXPIRE_OR_SERVER_ERROR:
@@ -59,4 +59,6 @@ export default {
     POSTED: "POSTED",
     DELETED: "DELETED",
   },
+
+  userListInfinitePageCount: 19,
 };

--- a/src/hooks/useUserInfiniteQuery.ts
+++ b/src/hooks/useUserInfiniteQuery.ts
@@ -1,0 +1,21 @@
+import { useInfiniteQuery } from "react-query";
+import { requestGetFilteredUsers2 } from "../utils/apis/introductions";
+
+const useMutationUserDeleteComment = (filters) => {
+  return useInfiniteQuery(
+    ["filteredUsers2", filters],
+    ({ pageParam }) => requestGetFilteredUsers2(filters, pageParam),
+    {
+      getNextPageParam: (lastPage) => {
+        // lastPage.data.data.values는 조회된 결과 값이다.
+        // 이 값이 0이면 더이상 불러올 값이 없다는 의미이기 때문에 undefined를 리턴한다.
+        // 여기서 undefined를 리턴하면 hasNextPage 값이 false가 되기 때문에 더이상 요청하지 않는다.
+        return lastPage.data.data.values.length === 0
+          ? undefined
+          : lastPage.data.data.nextLastId;
+      },
+    }
+  );
+};
+
+export default useMutationUserDeleteComment;

--- a/src/hooks/useUserInfiniteQuery.ts
+++ b/src/hooks/useUserInfiniteQuery.ts
@@ -14,6 +14,7 @@ const useMutationUserDeleteComment = (filters) => {
           ? undefined
           : lastPage.data.data.nextLastId;
       },
+      staleTime: 1000 * 10,
     }
   );
 };

--- a/src/utils/apis/introductions.ts
+++ b/src/utils/apis/introductions.ts
@@ -13,6 +13,19 @@ export const requestGetFilteredUsers = (filters) => {
   });
 };
 
+export const requestGetFilteredUsers2 = (filters, pageParam) => {
+  return necessaryAuthAxiosInstance.get("v1/introductions", {
+    params: {
+      name: filters.name ? filters.name : null,
+      generation: filters.generation ? filters.generation : null,
+      course: filters.course ? filters.course : null,
+      role: filters.role ? filters.role : null,
+      lastId: pageParam !== null ? pageParam : null,
+      size: filters.size ? filters.size : null,
+    },
+  });
+};
+
 export const requestGetIntroductions = (id) => {
   return necessaryAuthAxiosInstance.get(`v1/introductions/${id}`);
 };

--- a/src/utils/apis/introductions.ts
+++ b/src/utils/apis/introductions.ts
@@ -3,12 +3,12 @@ import necessaryAuthAxiosInstance from "./necessaryAuthAxiosInstance";
 export const requestGetFilteredUsers = (filters) => {
   return necessaryAuthAxiosInstance.get("v1/introductions", {
     params: {
-      name: filters.name ?? null,
-      generation: filters.generation ?? null,
-      course: filters.course ?? null,
-      role: filters.role ?? null,
-      nextLastId: filters.nextLastId ?? null,
-      size: filters.size ?? null,
+      name: filters.name ? filters.name : null,
+      generation: filters.generation ? filters.generation : null,
+      course: filters.course ? filters.course : null,
+      role: filters.role ? filters.role : null,
+      lastId: filters.nextLastId ? filters.nextLastId : null,
+      size: filters.size ? filters.size : null,
     },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7131,6 +7131,11 @@ react-icons@^4.3.1:
   resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz"
   integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
 
+react-intersection-observer@^8.33.1:
+  version "8.33.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.33.1.tgz#8e6442cac7052ed63056e191b7539e423e7d5c64"
+  integrity sha512-3v+qaJvp3D1MlGHyM+KISVg/CMhPiOlO6FgPHcluqHkx4YFCLuyXNlQ/LE6UkbODXlQcLOppfX6UMxCEkUhDLw==
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

데둥이 소개 리스트 무한 스크롤

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #105 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] break point 추가 (1200px 이상에서 볼 때 애매한 부분이 있어 추가)
- [x] 무한스크롤 구현
- [x] nullish 처리한 부분 원상복구 (빈 문자열일 경우 통과되면 안되므로)
- [x] 데둥이 상세페이지 댓글 버튼 visible 처리 로직 변경
- [x] react-intersection-observer 라이브러리 추가



## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.


https://user-images.githubusercontent.com/52060742/146390106-1575bda2-bee9-41ba-b12a-40394b31b0e6.mp4



## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 데둥이 리스트 좋아요 버튼 눌렀을 때 상세페이지로 라우팅 
  - 원래 좋아요를 붙이려고 했으나 좋아요 여부를 알 수 있는 liked 필드가 리스트에 없음 
- 무한 스크롤 1번 조회 개수는 19개로 함
  - 그 이유는 리스트의 형태가 grid 형태의 카드모양이기 때문에 초기에 보여지는 데이터의 수가 많을 수도 있음
- 데둥이 상세페이지 댓글 작성자 프로필 cursor 제거 
  - 원래 데둥이 상세페이지의 댓글에 작성자 프로필을 클릭하면 상대방의 상세 화면으로 가게 하려고 했으나 댓글에 introductionId가 없어 상세화면으로 가지 못함
- 좋아요 시 Lottie 일단 보류함 값의 변화에 따라서 애니메이션이 고르지 못하게 나오는 현상이 있어서 추후 적용할 예정 