### PR TITLE
DVT-#110 페이지별 사이드바 visible 처리

### DIFF
--- a/src/atoms/sidebarVisible.ts
+++ b/src/atoms/sidebarVisible.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const sidebarVisibleState = atom({
+  key: "sidebar",
+  default: true,
+});

--- a/src/pages/GatherClubPage/index.tsx
+++ b/src/pages/GatherClubPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherClubPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <GatherMainContainer selectedCategory="CLUB" />;
 };
 

--- a/src/pages/GatherDetailPage/index.tsx
+++ b/src/pages/GatherDetailPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherDetailContainer from "../../components/GatherDetail/GatherDetailContainer";
 
 const GatherDetailPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <GatherDetailContainer />;
 };
 

--- a/src/pages/GatherPage/index.tsx
+++ b/src/pages/GatherPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <GatherMainContainer />;
 };
 

--- a/src/pages/GatherProjectPage/index.tsx
+++ b/src/pages/GatherProjectPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherProjectPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <GatherMainContainer selectedCategory="PROJECT" />;
 };
 

--- a/src/pages/GatherStudyPage/index.tsx
+++ b/src/pages/GatherStudyPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherStudyPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <GatherMainContainer selectedCategory="STUDY" />;
 };
 

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import LoginContainer from "../../components/Login/LoginContainer";
 
 const LoginPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(false);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <LoginContainer />;
 };
 

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import MainContainer from "../../components/Main/MainContainer";
 
 const MainPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <MainContainer />;
 };
 

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import MyProfileContainer from "../../components/MyProfile/MyProfileContainer";
 
 const MyProfilePage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <MyProfileContainer />;
 };
 

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import SignupContainer from "../../components/Signup/SignupContainer";
 
 const index = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(false);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <SignupContainer />;
 };
 

--- a/src/pages/UserDetailPage/index.tsx
+++ b/src/pages/UserDetailPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import UserDetailContainer from "../../components/UserDetail/UserDetailContainer";
 
 const UserDetailPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <UserDetailContainer />;
 };
 

--- a/src/pages/UserListPage/index.tsx
+++ b/src/pages/UserListPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import UserListContainer from "../../components/UserList/UserListContainer";
 
 const UserListPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <UserListContainer />;
 };
 

--- a/src/pages/UsersMapPage/index.tsx
+++ b/src/pages/UsersMapPage/index.tsx
@@ -1,6 +1,15 @@
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import UsersMapContainer from "../../components/UsersMap/UsersMapContainer";
 
 const UserMapPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
+
   return <UsersMapContainer />;
 };
 

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -1,7 +1,8 @@
 import { ReactChild, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { globalMyProfile } from "../atoms";
+import { sidebarVisibleState } from "../atoms/sidebarVisible";
 import SidebarContainer from "../components/Sidebar/SidebarContainer";
 import { routes } from "../constants";
 import useMyProfile from "../hooks/useMyProfile";
@@ -13,7 +14,7 @@ interface Props {
 
 const DefaultTemplate = ({ children }: Props) => {
   // TODO: 페이지에 따라 사이드바를 보여줘야 하는지에 대한 여부를 팀원들과 논의하여 확정한 후에 하드코딩된 값을 제거하고 로직으로 변경한다.
-  const isShowSidebar = true;
+  const isShowSidebar = useRecoilValue(sidebarVisibleState);
   const { pathname } = useLocation();
   const [, setGlobalMyProfile] = useRecoilState(globalMyProfile);
   const { data } = useMyProfile(pathname);


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

페이지별 사이드바 visible 처리

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #110 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 페이지별 사이드바 visible 처리

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

없음

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- `src/pages` 하위에 있는 페이지 컴포넌트 들에 모두 추가했습니다. 추후 페이지 컴포넌트가 생긴다면 아래 내용을 꼭 추가해 주세요
```tsx
import { useRecoilState } from "recoil";
import { sidebarVisibleState } from "../../atoms/sidebarVisible";

const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);

useEffect(() => {
  setShowSidebar(true);
}, [isShowSidebar, setShowSidebar]);
```
- 원리는 이렇습니다. `sidebarVisibleState` 라는 atom을 만들고 해당 페이지들이 마운트 될 때 각자에 맞는 사이드바 보여짐 상태를 변경 -> DefaultTemplate에서 `sidebarVisibleState`를 구독하고 있기 때문에 처리 가능
- 더 좋은 아이디어가 있다면 마구 알려주세요!
