### PR TITLE
DVT-#135 탑바를 디폴트 템플릿으로 위치 변경

### DIFF
--- a/src/atoms/topbarVisble.ts
+++ b/src/atoms/topbarVisble.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const topbarVisibleState = atom({
+  key: "topbar",
+  default: true,
+});

--- a/src/components/Main/Main.test.tsx
+++ b/src/components/Main/Main.test.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider } from "@emotion/react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 
 import { MemoryRouter } from "react-router-dom";
 import { RecoilRoot } from "recoil";
@@ -44,13 +43,14 @@ describe("Main", () => {
     expect(screen.queryAllByText("모집 게시판")[0]).toBeInTheDocument();
   });
 
-  it("유저 프로필 이미지를 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
-    const profileImage = screen.getByAltText("유저 프로필 이미지");
+  // TODO: 더 이상 메인 컴포넌트의 역할이 아니므로 주석 처리한다. Cypress E2E 테스트로 옮기면 아래 주석을 삭제한다.
+  // it("유저 프로필 이미지를 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
+  //   const profileImage = screen.getByAltText("유저 프로필 이미지");
 
-    userEvent.click(profileImage);
+  //   userEvent.click(profileImage);
 
-    expect(screen.queryByText("프로필")).toBeVisible();
-    expect(screen.queryByText("내 모임 관리")).toBeVisible();
-    expect(screen.queryByText("로그아웃")).toBeVisible();
-  });
+  //   expect(screen.queryByText("프로필")).toBeVisible();
+  //   expect(screen.queryByText("내 모임 관리")).toBeVisible();
+  //   expect(screen.queryByText("로그아웃")).toBeVisible();
+  // });
 });

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -9,10 +9,8 @@ import Text from "../base/Text";
 import GatherList from "../GatherList/GatherList";
 import Mapgakco from "../Mapgakco/Mapgakco";
 import UserCardList from "../UserCardList/UserCardList";
-import UserImageAndDropdownContainer from "../UserImageAndDropdown/UserImageAndDropdownContainer";
 import {
   Contents,
-  Header,
   Container,
   MapgakcoAndGatherListContainer,
   SelfIntroduce,
@@ -38,14 +36,6 @@ const Main = ({ currentUser, userSuggestions, gatherSuggestions }: Props) => {
 
   return (
     <Container>
-      <Header>
-        <UserImageAndDropdownContainer
-          imageUrl={
-            currentUser?.introduction.profileImgUrl ||
-            common.placeHolderImageSrc
-          }
-        />
-      </Header>
       <Contents>
         <SelfIntroduce>
           <Text strong size={18}>

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import LoginContainer from "../../components/Login/LoginContainer";
 
 const LoginPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
 
   useEffect(() => {
     setShowSidebar(false);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <LoginContainer />;
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MainContainer from "../../components/Main/MainContainer";
 
 const MainPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <MainContainer />;
 };

--- a/src/pages/MapgakcoMapPage/index.tsx
+++ b/src/pages/MapgakcoMapPage/index.tsx
@@ -1,6 +1,18 @@
+import { useEffect } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MapgakcoMapContainer from "../../components/MapgakcoMap/MapgakcoMapContainer";
 
 const MapgakCoMapPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+
   return <MapgakcoMapContainer />;
 };
 

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MyProfileContainer from "../../components/MyProfile/MyProfileContainer";
 
 const MyProfilePage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <MyProfileContainer />;
 };

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import SignupContainer from "../../components/Signup/SignupContainer";
 
 const index = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
 
   useEffect(() => {
     setShowSidebar(false);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <SignupContainer />;
 };

--- a/src/pages/UsersMapPage/index.tsx
+++ b/src/pages/UsersMapPage/index.tsx
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UsersMapContainer from "../../components/UsersMap/UsersMapContainer";
 
 const UserMapPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <UsersMapContainer />;
 };

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -3,20 +3,25 @@ import { useLocation } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { globalMyProfile } from "../atoms";
 import { sidebarVisibleState } from "../atoms/sidebarVisible";
+import { topbarVisibleState } from "../atoms/topbarVisble";
 import SidebarContainer from "../components/Sidebar/SidebarContainer";
-import { routes } from "../constants";
+import UserImageAndDropdownContainer from "../components/UserImageAndDropdown/UserImageAndDropdownContainer";
+import { common, routes } from "../constants";
 import useMyProfile from "../hooks/useMyProfile";
-import { PageWrapper, Container } from "./styles";
+import { PageWrapper, Container, Header } from "./styles";
 
 interface Props {
   children: ReactChild;
 }
 
 const DefaultTemplate = ({ children }: Props) => {
-  // TODO: 페이지에 따라 사이드바를 보여줘야 하는지에 대한 여부를 팀원들과 논의하여 확정한 후에 하드코딩된 값을 제거하고 로직으로 변경한다.
   const isShowSidebar = useRecoilValue(sidebarVisibleState);
+  const isShowTopbar = useRecoilValue(topbarVisibleState);
+
   const { pathname } = useLocation();
-  const [, setGlobalMyProfile] = useRecoilState(globalMyProfile);
+
+  const [globalMyProfileData, setGlobalMyProfile] =
+    useRecoilState(globalMyProfile);
   const { data } = useMyProfile(pathname);
 
   useEffect(() => {
@@ -32,7 +37,19 @@ const DefaultTemplate = ({ children }: Props) => {
   return (
     <Container>
       {isShowSidebar && <SidebarContainer />}
-      <PageWrapper>{children}</PageWrapper>
+      <PageWrapper>
+        {isShowTopbar && (
+          <Header>
+            <UserImageAndDropdownContainer
+              imageUrl={
+                globalMyProfileData?.introduction.profileImgUrl ||
+                common.placeHolderImageSrc
+              }
+            />
+          </Header>
+        )}
+        {children}
+      </PageWrapper>
     </Container>
   );
 };

--- a/src/template/styles.ts
+++ b/src/template/styles.ts
@@ -10,3 +10,11 @@ export const PageWrapper = styled.div`
   height: 100%;
   overflow-x: hidden;
 `;
+
+export const Header = styled.header`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 12px;
+  background-color: ${({ theme }) => theme.colors.gray200};
+`;


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

탑바를 디폴트 템플릿으로 위치 변경한다. 각 페이지마다 유동적으로 탑바를 보여줄지를 결정한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #135 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 메인 컴포넌트에 있던 탑바를 제거한다.
- [x] 탑바 가시 여부를 전역 상태로 관리하여 페이지마다 동적으로 결정한다.
- [x] 기존 메인 컴포넌트에 있던 테스트 코드를 주석 처리한다. (Cypress로 옮길
예정)
- [x] 로그인, 회원가입, 프로필, 지도 사용하는 페이지에서는 탑바를 보여주지 않는다.

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

![image](https://user-images.githubusercontent.com/8105528/146591153-92eef9f3-3476-4e48-8662-37b42479f646.png)

공통으로 가시성 옵션을` true`로 넣은 탑바를 로그인 페이지에서는 보여주지 않습니다.

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 사이드바와 마찬가지 로직으로 탑바의 가시성 여부가 결정됩니다.
- 탑바의 백그라운드 색상이 문제가 됩니다. 와이어프레임 기준으로 작성되었는데 현재 다른 페이지와 배경 색상이 튀는 부분이 있어서 머지하기 전에 팀원들과 논의가 필요합니다.
- 모집게시판 페이지의 경우 뿡치의 작업과 충돌나지 않도록 변경하지 않았습니다. 각자 작업한 페이지에 적용이 안된 부분은 직접 적용해주세요.
