### PR TITLE
DVT-#129 모집 게시글 상세 페이지 레이아웃 수정 및 모집 마감, 게시글 수정 API 연동

### DIFF
--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -51,7 +51,7 @@ const Comment = ({
             course={author.course}
             generation={author.generation}
           />
-          {myProfile.user.userId === author.userId ? (
+          {myProfile?.user?.userId === author?.userId ? (
             <div>
               <DateText>{createdAt}</DateText>
 
@@ -102,7 +102,7 @@ const Comment = ({
               course={children[0].author.course}
               generation={children[0].author.generation}
             />
-            {myProfile.user.userId === children[0].author.userId ? (
+            {myProfile?.user?.userId === children[0]?.author?.userId ? (
               <div>
                 <DateText>{children[0].createdAt}</DateText>
                 {/* <button

--- a/src/components/GatherDetail/GatherDetail.tsx
+++ b/src/components/GatherDetail/GatherDetail.tsx
@@ -214,28 +214,16 @@ const GatherDetail = ({
           <Text size={18} strong>
             상세 내용
           </Text>
-          {isAuthor ? (
-            <MarkdownEditorWrapper>
-              <MarkdownEditor
-                editorRef={editorRef}
-                setEditorText={(value: string) =>
-                  setEditValue({ ...editValue, content: value })
-                }
-                value={editValue.content || ""}
-              />
-            </MarkdownEditorWrapper>
-          ) : (
-            <MarkdownEditorWrapper>
-              <MarkdownEditor
-                isViewMode
-                editorRef={editorRef}
-                setEditorText={(value: string) =>
-                  setEditValue({ ...editValue, content: value })
-                }
-                value={content || ""}
-              />
-            </MarkdownEditorWrapper>
-          )}
+          <MarkdownEditorWrapper>
+            <MarkdownEditor
+              isViewMode={!isAuthor}
+              editorRef={editorRef}
+              setEditorText={(value: string) =>
+                setEditValue({ ...editValue, content: value })
+              }
+              value={isAuthor ? editValue.content || "" : content || ""}
+            />
+          </MarkdownEditorWrapper>
         </TextContainer>
         <ButtonContainer>
           {!isAuthor && !isApplied && status === gatherStatus.GATHERING ? (

--- a/src/components/GatherDetail/GatherDetail.tsx
+++ b/src/components/GatherDetail/GatherDetail.tsx
@@ -217,7 +217,6 @@ const GatherDetail = ({
           {isAuthor ? (
             <MarkdownEditorWrapper>
               <MarkdownEditor
-                isViewMode={false}
                 editorRef={editorRef}
                 setEditorText={(value: string) =>
                   setEditValue({ ...editValue, content: value })
@@ -226,14 +225,16 @@ const GatherDetail = ({
               />
             </MarkdownEditorWrapper>
           ) : (
-            <Input
-              type="text"
-              name="deadline"
-              onChange={handleChange}
-              value={editValue.content}
-              disabled
-              customStyle={{ fontSize: "16px" }}
-            />
+            <MarkdownEditorWrapper>
+              <MarkdownEditor
+                isViewMode
+                editorRef={editorRef}
+                setEditorText={(value: string) =>
+                  setEditValue({ ...editValue, content: value })
+                }
+                value={content || ""}
+              />
+            </MarkdownEditorWrapper>
           )}
         </TextContainer>
         <ButtonContainer>

--- a/src/components/GatherDetail/GatherDetail.tsx
+++ b/src/components/GatherDetail/GatherDetail.tsx
@@ -1,9 +1,12 @@
 import { useRecoilValue } from "recoil";
+import { useState } from "react";
+import { BsFillPersonFill } from "react-icons/bs";
 import { Props } from "./types";
 import Text from "../base/Text";
 import CommentForm from "../CommentForm/CommentForm";
 import Comment from "../Comment/Comment";
 import ProfileBox from "../ProfileBox/ProfileBox";
+import Input from "../base/Input";
 import { globalMyProfile } from "../../atoms";
 import {
   Container,
@@ -13,6 +16,10 @@ import {
   TextContainer,
   ButtonContainer,
   CategoryWrapper,
+  EditDeadlineContainer,
+  Select,
+  EditContainer,
+  ApplicantContainer,
 } from "./styles";
 import theme from "../../assets/theme";
 import {
@@ -20,6 +27,11 @@ import {
   gatherDisplayStatus,
   gatherStatus,
 } from "../../constants";
+import MarkdownEditor from "../base/MarkdownEditor";
+import useToastUi from "../../hooks/useToastUi";
+import { MarkdownEditorWrapper } from "../MyProfile/styles";
+import ViewText from "../ViewText";
+import PeriodText from "../PeriodText";
 
 const GatherDetail = ({
   gatherData,
@@ -30,6 +42,7 @@ const GatherDetail = ({
   handleCommentSubmit,
   handleCommentDelete,
   handleCommentEdit,
+  handleGatherDetailEdit,
 }: Props): JSX.Element => {
   const {
     gatherId,
@@ -52,16 +65,30 @@ const GatherDetail = ({
     comments,
   } = gatherData;
 
+  const [editorRef] = useToastUi();
+
+  const [editValue, setEditValue] = useState({
+    title,
+    content,
+    category,
+    deadline: deadline.substring(0, 10),
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setEditValue({
+      ...editValue,
+      [name]: value,
+    });
+  };
+
   const myProfile = useRecoilValue(globalMyProfile);
+
+  const isAuthor = myProfile?.user?.userId === author?.userId;
 
   return (
     <Container>
       <CategoryWrapper>
-        <Category>
-          <Text size={12} color={theme.colors.white}>
-            {categoryDisplayName[category]}
-          </Text>
-        </Category>
         {status !== gatherStatus.GATHERING ? (
           <Category>
             <Text size={12} color={theme.colors.white}>
@@ -69,10 +96,54 @@ const GatherDetail = ({
             </Text>
           </Category>
         ) : undefined}
+        {isAuthor ? (
+          <EditContainer>
+            <label
+              htmlFor="category"
+              style={{ fontSize: "18px", fontWeight: 700 }}
+            >
+              카테고리
+            </label>
+            <Select
+              name="category"
+              value={editValue.category}
+              onChange={handleChange}
+            >
+              <option value={category}>{categoryDisplayName[category]}</option>
+              {Object.keys(categoryDisplayName).map((item) =>
+                item !== category ? (
+                  <option key={item} value={item}>
+                    {categoryDisplayName[item]}
+                  </option>
+                ) : undefined
+              )}
+            </Select>
+          </EditContainer>
+        ) : (
+          <Category>
+            <Text size={12} color={theme.colors.white}>
+              {categoryDisplayName[category]}
+            </Text>
+          </Category>
+        )}
       </CategoryWrapper>
-      <Text size={24} strong>
-        {title}
-      </Text>
+      {isAuthor ? (
+        <EditContainer>
+          <label htmlFor="title" style={{ fontSize: "18px", fontWeight: 700 }}>
+            제목
+          </label>
+          <Input
+            type="text"
+            name="title"
+            onChange={handleChange}
+            value={editValue.title}
+          />
+        </EditContainer>
+      ) : (
+        <Text size={24} strong>
+          {title}
+        </Text>
+      )}
       <UserContainer>
         <ProfileBox
           src={author?.profileImgUrl}
@@ -80,61 +151,123 @@ const GatherDetail = ({
           name={author.name}
           course={author.course}
           generation={author.generation}
+          fontSize={16}
         />
-        <Text>{createdAt}</Text>
-        <Text>{view}</Text>
+        <Text>{createdAt.substring(0, 10)}</Text>
+        <ViewText
+          view={view}
+          iconColor={theme.colors.gray500}
+          fontColor={theme.colors.gray600}
+        />
       </UserContainer>
       <DetailContainer>
         <TextContainer>
-          <Text size={18}>모집 기간</Text>
-          <Text>{`${createdAt}~${deadline}`}</Text>
+          <Text size={18} strong>
+            모집 기간
+          </Text>
+          {isAuthor ? (
+            <EditDeadlineContainer>
+              <Text>{`${createdAt.substring(0, 10)} ~ `}</Text>
+              <Input
+                type="text"
+                name="deadline"
+                onChange={handleChange}
+                value={editValue.deadline}
+                customStyle={{ width: "30%" }}
+              />
+            </EditDeadlineContainer>
+          ) : (
+            <PeriodText
+              createdDate={createdAt.substring(0, 10)}
+              deadLine={deadline.substring(0, 10)}
+            />
+          )}
         </TextContainer>
         <TextContainer>
-          <Text size={18}>모집 인원</Text>
+          <Text size={18} strong>
+            모집 인원
+          </Text>
           <Text>{`${applicantLimit}명`}</Text>
         </TextContainer>
         <TextContainer>
-          <Text size={18}>신청 인원</Text>
+          <Text size={18} strong>
+            신청 인원
+          </Text>
           <Text>{`${applicantCount}명`}</Text>
           {participants?.map((applicant) => {
             return (
-              <ProfileBox
-                key={applicant.name}
-                src={applicant.profileImgUrl}
-                alt="프로필"
-                name={applicant.name}
-                course={applicant.course}
-                generation={applicant.generation}
-              />
+              <ApplicantContainer key={applicant.name}>
+                <BsFillPersonFill />
+                <ProfileBox
+                  src={applicant.profileImgUrl}
+                  alt="프로필"
+                  name={applicant.name}
+                  course={applicant.course}
+                  generation={applicant.generation}
+                  fontSize={14}
+                />
+              </ApplicantContainer>
             );
           })}
         </TextContainer>
         <TextContainer>
-          <Text size={18}>상세 내용</Text>
-          <Text>{content}</Text>
+          <Text size={18} strong>
+            상세 내용
+          </Text>
+          {isAuthor ? (
+            <MarkdownEditorWrapper>
+              <MarkdownEditor
+                isViewMode={false}
+                editorRef={editorRef}
+                setEditorText={(value: string) =>
+                  setEditValue({ ...editValue, content: value })
+                }
+                value={editValue.content || ""}
+              />
+            </MarkdownEditorWrapper>
+          ) : (
+            <Input
+              type="text"
+              name="deadline"
+              onChange={handleChange}
+              value={editValue.content}
+              disabled
+              customStyle={{ fontSize: "16px" }}
+            />
+          )}
         </TextContainer>
         <ButtonContainer>
-          {myProfile?.user?.userId !== author.userId && isApplied ? (
-            <button type="button" onClick={() => handleGatherCancel(gatherId)}>
-              취소
-            </button>
-          ) : (
+          {!isAuthor && !isApplied && status === gatherStatus.GATHERING ? (
             <button type="button" onClick={() => handleGatherApply(gatherId)}>
               신청
             </button>
-          )}
-          {myProfile?.user?.userId === author.userId ? (
+          ) : undefined}
+          {!isAuthor && isApplied && status !== gatherStatus.DELETED ? (
+            <button type="button" onClick={() => handleGatherCancel(gatherId)}>
+              취소
+            </button>
+          ) : undefined}
+          {isAuthor &&
+          (status === gatherStatus.GATHERING ||
+            status === gatherStatus.FULL) ? (
             <>
-              <button type="button" onClick={() => handleGatherClose(gatherId)}>
-                모집 마감
-              </button>
               <button
                 type="button"
-                onClick={() => handleGatherDelete(gatherId)}
+                onClick={() =>
+                  handleGatherDetailEdit({ ...editValue, gatherId })
+                }
               >
-                모집 삭제
+                수정
+              </button>
+              <button type="button" onClick={() => handleGatherClose(gatherId)}>
+                마감
               </button>
             </>
+          ) : undefined}
+          {isAuthor && status !== gatherStatus.DELETED ? (
+            <button type="button" onClick={() => handleGatherDelete(gatherId)}>
+              삭제
+            </button>
           ) : undefined}
         </ButtonContainer>
       </DetailContainer>

--- a/src/components/GatherDetail/GatherDetailContainer.tsx
+++ b/src/components/GatherDetail/GatherDetailContainer.tsx
@@ -11,6 +11,8 @@ import useCreateGatherComment from "../../hooks/useCreateGatherComment";
 import useDeleteGather from "../../hooks/useDeleteGather";
 import useDeleteComment from "../../hooks/useDeleteComment";
 import useEditComment from "../../hooks/useEditComment";
+import useEditGatherDetail from "../../hooks/useEditGatherDetail";
+import useClosGather from "../../hooks/useCloseGather";
 
 const GatherDetailContainer = () => {
   const { id } = useParams<{ id: string }>();
@@ -25,6 +27,8 @@ const GatherDetailContainer = () => {
   const { deleteGather } = useDeleteGather();
   const { deleteComment } = useDeleteComment();
   const { editComment } = useEditComment();
+  const { editGather } = useEditGatherDetail();
+  const { closeGather } = useClosGather();
 
   // TODO: API 호출 로직 작성 필요
 
@@ -35,6 +39,7 @@ const GatherDetailContainer = () => {
 
   const handleGatherClose = (gatherId) => {
     console.log("모임 마감", gatherId);
+    closeGather(gatherId);
   };
 
   const handleGatherApply = (gatherId) => {
@@ -63,6 +68,11 @@ const GatherDetailContainer = () => {
     editComment(editValue);
   };
 
+  const handleGatherDetailEdit = (editValue) => {
+    console.log("모집 게시글 수정", editValue);
+    editGather(editValue);
+  };
+
   return (
     <div>
       {data ? (
@@ -75,6 +85,7 @@ const GatherDetailContainer = () => {
           handleGatherCancel={handleGatherCancel}
           handleGatherClose={handleGatherClose}
           handleGatherDelete={handleGatherDelete}
+          handleGatherDetailEdit={handleGatherDetailEdit}
         />
       ) : undefined}
     </div>

--- a/src/components/GatherDetail/styles.ts
+++ b/src/components/GatherDetail/styles.ts
@@ -7,10 +7,13 @@ export const Container = styled.div`
   margin: 0 auto;
   overflow-y: auto;
   height: 100%;
+  gap: 8px;
 `;
 
 export const CategoryWrapper = styled.div`
   display: flex;
+  flex-direction: column;
+  gap: 4px;
 `;
 
 export const Category = styled.div`
@@ -41,21 +44,66 @@ export const DetailContainer = styled.div`
 export const TextContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 7px;
-  padding: 10px 0;
+  gap: 8px;
+  padding: 12px 0;
 `;
 
 export const ButtonContainer = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 10px 0;
+  gap: 16px;
 
   button {
-    font-size: 18px;
+    font-size: 16px;
     border: none;
     background-color: ${({ theme }) => theme.colors.skyblue};
     border-radius: 4px;
     padding: 5px 3px;
+    width: 100px;
+    height: 40px;
   }
+`;
+
+export const EditDeadlineContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const Select = styled.select`
+  width: 100%;
+  color: ${({ theme }) => theme.colors?.gray800};
+  padding: 16px;
+  border: none;
+  background: ${({ theme }) => theme.colors?.white};
+  border-radius: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: ${({ theme }) => theme.boxShadows.primary};
+  -o-appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  input {
+    width: 80%;
+  }
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors?.gray300};
+  }
+`;
+
+export const EditContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+`;
+
+export const ApplicantContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;

--- a/src/components/GatherDetail/types.ts
+++ b/src/components/GatherDetail/types.ts
@@ -11,6 +11,15 @@ export interface EditommentProps {
   commentId: number;
   content: string;
 }
+
+export interface EditGatherProps {
+  gatherId: number;
+  title: string;
+  content: string;
+  deadline: string;
+  category: string;
+}
+
 export interface Props {
   gatherData: Gather;
   handleGatherDelete: (arg: number) => void;
@@ -20,4 +29,5 @@ export interface Props {
   handleCommentSubmit: (arg: SubmitProps) => void;
   handleCommentDelete: (arg: DeleteCommentProps) => void;
   handleCommentEdit: (arg: EditommentProps) => void;
+  handleGatherDetailEdit: (arg: EditGatherProps) => void;
 }

--- a/src/components/GatherList/GatherList.tsx
+++ b/src/components/GatherList/GatherList.tsx
@@ -96,8 +96,8 @@ const GatherList = ({ selectedCategory, gatherData, page }: Props) => {
               </TextContainer>
               <InfoWrapper page={page}>
                 <PeriodText
-                  createdDate={item.createdAt}
-                  deadLine={item.deadline}
+                  createdDate={item.createdAt.substring(0, 10)}
+                  deadLine={item.deadline.substring(0, 10)}
                   iconColor={theme.colors.gray500}
                   fontColor={theme.colors.gray600}
                 />

--- a/src/hooks/useCloseGather.ts
+++ b/src/hooks/useCloseGather.ts
@@ -8,9 +8,9 @@ const useClosGather = () => {
     (gatherId) => requestCloseGather(gatherId),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries("gatherDetail");
         // TODO:
         // eslint-disable-next-line no-alert
-        queryClient.invalidateQueries("gatherDetail");
         alert("모집이 마감되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/hooks/useCloseGather.ts
+++ b/src/hooks/useCloseGather.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "react-query";
+import { MutationData, MutationError } from "../types/commonTypes";
+import { requestCloseGather } from "../utils/apis/gather";
+
+const useClosGather = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
+    (gatherId) => requestCloseGather(gatherId),
+    {
+      onSuccess: () => {
+        // TODO:
+        // eslint-disable-next-line no-alert
+        queryClient.invalidateQueries("gatherDetail");
+        alert("모집이 마감되었습니다.");
+      },
+      onError: ({ response }) => {
+        const errorMessage = response?.data?.message;
+        // TODO:
+        // eslint-disable-next-line no-alert
+        alert(errorMessage);
+      },
+    }
+  );
+
+  return { closeGather: mutate };
+};
+
+export default useClosGather;

--- a/src/hooks/useCreateGatherComment.ts
+++ b/src/hooks/useCreateGatherComment.ts
@@ -1,14 +1,16 @@
-import { useMutation } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestCreateComment } from "../utils/apis/gather";
 
 const useCreateGatherComment = () => {
+  const queryClient = useQueryClient();
   const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
     (submitValue) => requestCreateComment(submitValue),
     {
       onSuccess: () => {
         // TODO:
         // eslint-disable-next-line no-alert
+        queryClient.invalidateQueries("FilteredGathers");
         alert("댓글이 작성되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/hooks/useCreateGatherComment.ts
+++ b/src/hooks/useCreateGatherComment.ts
@@ -8,9 +8,9 @@ const useCreateGatherComment = () => {
     (submitValue) => requestCreateComment(submitValue),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries("FilteredGathers");
         // TODO:
         // eslint-disable-next-line no-alert
-        queryClient.invalidateQueries("FilteredGathers");
         alert("댓글이 작성되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/hooks/useDeleteComment.ts
+++ b/src/hooks/useDeleteComment.ts
@@ -8,9 +8,9 @@ const useDeleteComment = () => {
     (deleteValue) => requestDeleteComment(deleteValue),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries("gatherDetail");
         // TODO:
         // eslint-disable-next-line no-alert
-        queryClient.invalidateQueries("gatherDetail");
         alert("댓글이 삭제되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/hooks/useDeleteComment.ts
+++ b/src/hooks/useDeleteComment.ts
@@ -1,14 +1,16 @@
-import { useMutation } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestDeleteComment } from "../utils/apis/gather";
 
 const useDeleteComment = () => {
+  const queryClient = useQueryClient();
   const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
     (deleteValue) => requestDeleteComment(deleteValue),
     {
       onSuccess: () => {
         // TODO:
         // eslint-disable-next-line no-alert
+        queryClient.invalidateQueries("gatherDetail");
         alert("댓글이 삭제되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/hooks/useDeleteGather.ts
+++ b/src/hooks/useDeleteGather.ts
@@ -1,8 +1,11 @@
 import { useMutation } from "react-query";
+import { useHistory } from "react-router-dom";
+import { routes } from "../constants";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestDeleteGather } from "../utils/apis/gather";
 
 const useDeleteGather = () => {
+  const history = useHistory();
   const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
     (gatherId) => requestDeleteGather(gatherId),
     {
@@ -10,6 +13,7 @@ const useDeleteGather = () => {
         // TODO:
         // eslint-disable-next-line no-alert
         alert("모집글이 삭제되었습니다.");
+        history.push(routes.MYGATHERLIST);
       },
       onError: ({ response }) => {
         const errorMessage = response?.data?.message;

--- a/src/hooks/useEditGatherDetail.ts
+++ b/src/hooks/useEditGatherDetail.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "react-query";
+import { MutationData, MutationError } from "../types/commonTypes";
+import { requestEditGatherDetail } from "../utils/apis/gather";
+
+const useEditGatherDetail = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
+    (editValue) => requestEditGatherDetail(editValue),
+    {
+      onSuccess: () => {
+        // TODO:
+        // eslint-disable-next-line no-alert
+        queryClient.invalidateQueries("gatherDetail");
+        alert("모집글이 수정되었습니다.");
+      },
+      onError: ({ response }) => {
+        const errorMessage = response?.data?.message;
+        // TODO:
+        // eslint-disable-next-line no-alert
+        alert(errorMessage);
+      },
+    }
+  );
+
+  return { editGather: mutate };
+};
+
+export default useEditGatherDetail;

--- a/src/hooks/useEditGatherDetail.ts
+++ b/src/hooks/useEditGatherDetail.ts
@@ -8,9 +8,9 @@ const useEditGatherDetail = () => {
     (editValue) => requestEditGatherDetail(editValue),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries("gatherDetail");
         // TODO:
         // eslint-disable-next-line no-alert
-        queryClient.invalidateQueries("gatherDetail");
         alert("모집글이 수정되었습니다.");
       },
       onError: ({ response }) => {

--- a/src/utils/apis/gather.ts
+++ b/src/utils/apis/gather.ts
@@ -50,3 +50,16 @@ export const requestEditComment = (editValue) => {
 export const requestDeleteGather = (gatherId) => {
   return necessaryAuthAxiosInstance.delete(`v1/gathers/${gatherId}`);
 };
+
+export const requestEditGatherDetail = (editValue) => {
+  return necessaryAuthAxiosInstance.patch(`v1/gathers/${editValue.gatherId}`, {
+    title: editValue.title,
+    content: editValue.content,
+    category: editValue.category,
+    deadline: editValue.deadline,
+  });
+};
+
+export const requestCloseGather = (gatherId) => {
+  return necessaryAuthAxiosInstance.patch(`v1/gathers/${gatherId}/close`);
+};


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

모집게시글 상세 페이지의 전체적인 레이아웃 변경과 모집 게시글 수정, 모집 마감 API를 연동한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #129 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 모집게시글 페이지의 상세내용을 적는 란은 마크다운 에디터로 변경
- [x] 게시글 작성자, 모집 상태, 지원 여부에 따라 보이는 버튼 다르게 로직 추가
- [x] 게시글 작성자는 게시글 상세 페이지에서 수정이 가능한 input창과 마크다운으로 보이도록 변경
- [x] 모집 마감 API 연동
- [x] 모집 게시글 API 연동

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

**모집 게시글 작성자가 상세 페이지에 접속했을 떄**
![screencapture-localhost-8000-gatherlist-2-2021-12-18-03_52_41](https://user-images.githubusercontent.com/55550034/146604119-67c50e76-45bf-49d7-9c05-76e327fce5e9.png)

**작성자가 아닌 일반 유저가 접속했을 때**
![screencapture-localhost-8000-gatherlist-6-2021-12-18-05_55_38](https://user-images.githubusercontent.com/55550034/146607376-3b6a60a8-301b-4676-bb03-cbf139e5f0ab.png)



## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 댓글 관련 API는 댓글 수정 빼고 모두 연동했지만 레이아웃을 수정해야해서 댓글 부분은 좀 이상하게 보입니다!(대댓글이 대댓글처럼 안보인다)