### PR TITLE
DVT-#141 탑바 스타일을 전역 상태로 관리

### DIFF
--- a/src/atoms/topbarBgColor.ts
+++ b/src/atoms/topbarBgColor.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const topbarBgColorState = atom({
+  key: "topbarBgColor",
+  default: "#fff",
+});

--- a/src/atoms/topbarBgColor.ts
+++ b/src/atoms/topbarBgColor.ts
@@ -1,6 +1,7 @@
 import { atom } from "recoil";
+import theme from "../assets/theme";
 
 export const topbarBgColorState = atom({
   key: "topbarBgColor",
-  default: "#fff",
+  default: `${theme.colors.white}`,
 });

--- a/src/components/Main/styles.ts
+++ b/src/components/Main/styles.ts
@@ -7,6 +7,7 @@ export const Container = styled.div`
   flex-direction: column;
   height: 100%;
   background-color: ${({ theme }) => theme.colors.gray200};
+  overflow-y: auto;
 `;
 
 export const Header = styled.header`

--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import AdminContainer from "../../components/Admin/AdminContainer";
 
 const AdminPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <AdminContainer />;
 };

--- a/src/pages/GatherClubPage/index.tsx
+++ b/src/pages/GatherClubPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherClubPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="CLUB" />;
 };

--- a/src/pages/GatherPage/index.tsx
+++ b/src/pages/GatherPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer />;
 };

--- a/src/pages/GatherProjectPage/index.tsx
+++ b/src/pages/GatherProjectPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherProjectPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="PROJECT" />;
 };

--- a/src/pages/GatherStudyPage/index.tsx
+++ b/src/pages/GatherStudyPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherStudyPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="STUDY" />;
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,17 +1,21 @@
 import { useEffect } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
+import theme from "../../assets/theme";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MainContainer from "../../components/Main/MainContainer";
 
 const MainPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setTopbarColor = useSetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
     setShowTopbar(true);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+    setTopbarColor(theme.colors.gray200);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar, setTopbarColor]);
 
   return <MainContainer />;
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -9,13 +9,13 @@ import MainContainer from "../../components/Main/MainContainer";
 const MainPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setTopbarColor = useSetRecoilState(topbarBgColorState);
+  const setTopbarBgColor = useSetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
     setShowTopbar(true);
-    setTopbarColor(theme.colors.gray200);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar, setTopbarColor]);
+    setTopbarBgColor(theme.colors.gray200);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar, setTopbarBgColor]);
 
   return <MainContainer />;
 };

--- a/src/pages/MyGatherPage/index.tsx
+++ b/src/pages/MyGatherPage/index.tsx
@@ -1,6 +1,18 @@
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState } from "recoil";
+import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import MyGatherContainer from "../../components/MyGather/MyGatherContainer";
 
 const MyGatherPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
+
+  useEffect(() => {
+    setShowSidebar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar]);
+
   return <MyGatherContainer />;
 };
 

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,17 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MyProfileContainer from "../../components/MyProfile/MyProfileContainer";
 
 const MyProfilePage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
     setShowTopbar(true);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <MyProfileContainer />;
 };

--- a/src/pages/UserListPage/index.tsx
+++ b/src/pages/UserListPage/index.tsx
@@ -1,14 +1,20 @@
 import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
+import { topbarBgColorState } from "../../atoms/topbarBgColor";
+import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UserListContainer from "../../components/UserList/UserListContainer";
 
 const UserListPage = () => {
   const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
   useEffect(() => {
     setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <UserListContainer />;
 };

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { globalMyProfile } from "../atoms";
 import { sidebarVisibleState } from "../atoms/sidebarVisible";
+import { topbarBgColorState } from "../atoms/topbarBgColor";
 import { topbarVisibleState } from "../atoms/topbarVisble";
 import SidebarContainer from "../components/Sidebar/SidebarContainer";
 import UserImageAndDropdownContainer from "../components/UserImageAndDropdown/UserImageAndDropdownContainer";
@@ -17,6 +18,7 @@ interface Props {
 const DefaultTemplate = ({ children }: Props) => {
   const isShowSidebar = useRecoilValue(sidebarVisibleState);
   const isShowTopbar = useRecoilValue(topbarVisibleState);
+  const topbarBgColor = useRecoilValue(topbarBgColorState);
 
   const { pathname } = useLocation();
 
@@ -39,7 +41,7 @@ const DefaultTemplate = ({ children }: Props) => {
       {isShowSidebar && <SidebarContainer />}
       <PageWrapper>
         {isShowTopbar && (
-          <Header>
+          <Header topbarBgColor={topbarBgColor}>
             <UserImageAndDropdownContainer
               imageUrl={
                 globalMyProfileData?.introduction.profileImgUrl ||

--- a/src/template/styles.ts
+++ b/src/template/styles.ts
@@ -13,10 +13,10 @@ export const PageWrapper = styled.div`
   flex-direction: column;
 `;
 
-export const Header = styled.header`
+export const Header = styled.header<{ topbarBgColor }>`
   display: flex;
   justify-content: flex-end;
   align-items: center;
   padding: 12px;
-  background-color: ${({ theme }) => theme.colors.gray200};
+  background-color: ${({ topbarBgColor }) => topbarBgColor};
 `;

--- a/src/template/styles.ts
+++ b/src/template/styles.ts
@@ -9,6 +9,8 @@ export const PageWrapper = styled.div`
   flex-grow: 1;
   height: 100%;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const Header = styled.header`


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

페이지마다 탑바 색상을 유동적으로 관리할 수 있도록 변경한다

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #141 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 탑바 색상을 전역으로  관리한다
- [x] 각 페이지마다 탑바 색상을 유동적으로 관리할 수 있다

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

![image](https://user-images.githubusercontent.com/8105528/146632945-43a8aaf2-0253-40e9-810a-b9f31dee8892.png)

![image](https://user-images.githubusercontent.com/8105528/146634230-5be4a213-d38e-4fee-b2fc-2bdfd6ccaa56.png)

![image](https://user-images.githubusercontent.com/8105528/146634233-ae8f6a48-6bc3-4536-a78e-30ec3114ac97.png)


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음
