### PR TITLE
DVT-#140 회원가입 링크 생성 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-markdown": "^7.1.1",
     "react-query": "^3.34.0",
     "react-router-dom": "^5.3.0",
+    "react-toastify": "^8.1.0",
     "recoil": "^0.5.2",
     "yup": "^0.32.11"
   },

--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -17,6 +17,7 @@ import {
   LinkInformationContainer,
   InviteLinkBorderContainer,
   DatePicker,
+  Th,
 } from "./styles";
 import { common, admin } from "../../constants";
 import Text from "../base/Text";
@@ -28,25 +29,25 @@ interface FormValues {
   course: string;
   generation: string;
   role: string;
-  expireDate: string;
+  deadline: string;
 }
 
 const testDatas = [
   {
-    id: "1",
+    uuid: "dsfkljfsdlkjdfslkj",
     course: "FE",
     generation: "1",
     role: "STUDENT",
     link: "http://test3.com",
-    expireDate: "20211219",
+    deadline: "20211219",
   },
   {
-    id: "2",
+    uuid: "afdsdsfjlkndfslkjh",
     course: "FE",
     generation: "2",
     role: "STUDENT",
     link: "http://test2.com",
-    expireDate: "20211219",
+    deadline: "20211219",
   },
 ];
 
@@ -61,15 +62,14 @@ const Admin = () => {
     values,
     errors,
   }: FormikProps<FormValues> = useFormik<FormValues>({
-    initialValues: { course: "", generation: "", role: "", expireDate: "" },
+    initialValues: { course: "", generation: "", role: "", deadline: "" },
     validationSchema: adminValidator,
     onSubmit: (formValues, { setSubmitting }) => {
       setSubmitting(true);
-
       mutate({
         ...formValues,
-        expireDate: formValues.expireDate
-          ? dayjs(formValues.expireDate).format("YYYY-MM-DD")
+        deadline: formValues.deadline
+          ? dayjs(formValues.deadline).format("YYYY-MM-DD")
           : null,
       });
       setSubmitting(false);
@@ -162,10 +162,10 @@ const Admin = () => {
             <SelectAndErrorMessageContainer>
               <DatePicker
                 type="date"
-                name="expireDate"
+                name="deadline"
                 min={dayjs(new Date()).format("YYYY-MM-DD")}
                 max="9999-12-31"
-                value={values.expireDate}
+                value={values.deadline}
                 onChange={handleChange}
               />
             </SelectAndErrorMessageContainer>
@@ -185,13 +185,58 @@ const Admin = () => {
             현재 유효한 초대 링크가 없습니다 😥
           </Text>
         )}
+        <table>
+          <thead>
+            <tr>
+              <Th>
+                <span>코스</span>
+              </Th>
+              <Th>
+                <span>기수</span>
+              </Th>
+              <Th>
+                <span>역할</span>
+              </Th>
+              <Th>
+                <span>링크</span>
+              </Th>
+              <Th>
+                <span>만료일</span>
+              </Th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>6,000</td>
+              <td>110</td>
+              <td>1.8%</td>
+              <td>22.2</td>
+              <td>22.2</td>
+            </tr>
+            <tr>
+              <td>6,000</td>
+              <td>110</td>
+              <td>1.8%</td>
+              <td>22.2</td>
+              <td>22.2</td>
+            </tr>
+            <tr>
+              <td>6,000</td>
+              <td>110</td>
+              <td>1.8%</td>
+              <td>22.2</td>
+              <td>22.2</td>
+            </tr>
+          </tbody>
+        </table>
+
         <ul>
           {testDatas.map((testData) => (
-            <InviteLinkLi key={testData.link}>
+            <InviteLinkLi key={testData.uuid}>
               <LinkInformationContainer>
                 {`${testData.course} / ${testData.generation} / ${
                   testData.role
-                } / ${testData.link} / ${dayjs(testData.expireDate).format(
+                } / ${testData.link} / ${dayjs(testData.deadline).format(
                   "YYYY-MM-DD"
                 )}`}
               </LinkInformationContainer>

--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -13,17 +13,18 @@ import {
   ErrorMessage,
   SelectAndErrorMessageContainer,
   SelectContainer,
-  InviteLinkLi,
-  LinkInformationContainer,
   InviteLinkBorderContainer,
   DatePicker,
   Th,
+  Td,
+  Tr,
 } from "./styles";
 import { common, admin } from "../../constants";
 import Text from "../base/Text";
 import useMutationInviteLink from "../../hooks/useMutationInviteLink";
 import useQueryInviteLink from "../../hooks/useQueryInviteLink";
 import useCopyClipboard from "../../hooks/useCopyClipboard";
+import useCustomToast from "../../hooks/useCustomToast";
 
 interface FormValues {
   course: string;
@@ -32,28 +33,12 @@ interface FormValues {
   deadline: string;
 }
 
-const testDatas = [
-  {
-    uuid: "dsfkljfsdlkjdfslkj",
-    course: "FE",
-    generation: "1",
-    role: "STUDENT",
-    link: "http://test3.com",
-    deadline: "20211219",
-  },
-  {
-    uuid: "afdsdsfjlkndfslkjh",
-    course: "FE",
-    generation: "2",
-    role: "STUDENT",
-    link: "http://test2.com",
-    deadline: "20211219",
-  },
-];
-
 const Admin = () => {
-  const { data, isLoading } = useQueryInviteLink();
+  const { data } = useQueryInviteLink();
   const { mutate } = useMutationInviteLink();
+
+  const [toast] = useCustomToast();
+
   const {
     handleSubmit,
     handleChange,
@@ -64,7 +49,7 @@ const Admin = () => {
   }: FormikProps<FormValues> = useFormik<FormValues>({
     initialValues: { course: "", generation: "", role: "", deadline: "" },
     validationSchema: adminValidator,
-    onSubmit: (formValues, { setSubmitting }) => {
+    onSubmit: (formValues, { setSubmitting, resetForm }) => {
       setSubmitting(true);
       mutate({
         ...formValues,
@@ -73,14 +58,12 @@ const Admin = () => {
           : null,
       });
       setSubmitting(false);
+      resetForm();
+      toast({ message: "링크 생성이 완료되었습니다 😄" });
     },
   });
 
   const [handleCopyClick] = useCopyClipboard();
-
-  // TODO: API 연동되면 지울 예정
-  // eslint-disable-next-line
-  console.log(data, isLoading);
 
   useEffect(() => {
     dayjs.extend(relativeTime);
@@ -167,7 +150,11 @@ const Admin = () => {
                 max="9999-12-31"
                 value={values.deadline}
                 onChange={handleChange}
+                onBlur={handleBlur}
               />
+              {touched.deadline && !!errors.deadline && (
+                <ErrorMessage>{errors.deadline}</ErrorMessage>
+              )}
             </SelectAndErrorMessageContainer>
           </SelectContainer>
 
@@ -179,73 +166,52 @@ const Admin = () => {
         <Text size={24} strong>
           유효한 초대 링크 목록
         </Text>
-
-        {testDatas?.length === 0 && (
+        {data?.data.data.length === 0 && (
           <Text size={16} strong>
             현재 유효한 초대 링크가 없습니다 😥
           </Text>
         )}
-        <table>
-          <thead>
-            <tr>
-              <Th>
-                <span>코스</span>
-              </Th>
-              <Th>
-                <span>기수</span>
-              </Th>
-              <Th>
-                <span>역할</span>
-              </Th>
-              <Th>
-                <span>링크</span>
-              </Th>
-              <Th>
-                <span>만료일</span>
-              </Th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>6,000</td>
-              <td>110</td>
-              <td>1.8%</td>
-              <td>22.2</td>
-              <td>22.2</td>
-            </tr>
-            <tr>
-              <td>6,000</td>
-              <td>110</td>
-              <td>1.8%</td>
-              <td>22.2</td>
-              <td>22.2</td>
-            </tr>
-            <tr>
-              <td>6,000</td>
-              <td>110</td>
-              <td>1.8%</td>
-              <td>22.2</td>
-              <td>22.2</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <ul>
-          {testDatas.map((testData) => (
-            <InviteLinkLi key={testData.uuid}>
-              <LinkInformationContainer>
-                {`${testData.course} / ${testData.generation} / ${
-                  testData.role
-                } / ${testData.link} / ${dayjs(testData.deadline).format(
-                  "YYYY-MM-DD"
-                )}`}
-              </LinkInformationContainer>
-              <Button type="button" onClick={handleCopyClick(testData.link)}>
-                링크 복사
-              </Button>
-            </InviteLinkLi>
-          ))}
-        </ul>
+        {data?.data.data.length !== 0 && (
+          <table>
+            <thead>
+              <tr>
+                <Th>
+                  <span>코스</span>
+                </Th>
+                <Th>
+                  <span>기수</span>
+                </Th>
+                <Th>
+                  <span>역할</span>
+                </Th>
+                <Th>
+                  <span>만료일</span>
+                </Th>
+                <Th />
+              </tr>
+            </thead>
+            <tbody>
+              {data?.data.data.map((inviteLink) => (
+                <Tr key={inviteLink.uuid}>
+                  <Td>{common.courseMap[inviteLink.course]}</Td>
+                  <Td>{inviteLink.generation}</Td>
+                  <Td>{common.roleMap[inviteLink.role]}</Td>
+                  <Td>{dayjs(inviteLink.deadline).format("YYYY-MM-DD")}</Td>
+                  <Td>
+                    <Button
+                      type="button"
+                      onClick={handleCopyClick(
+                        `${process.env.DOMAIN}signup/${inviteLink.uuid}`
+                      )}
+                    >
+                      링크 복사
+                    </Button>
+                  </Td>
+                </Tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </InviteLinkBorderContainer>
     </Container>
   );

--- a/src/components/Admin/styles.ts
+++ b/src/components/Admin/styles.ts
@@ -64,7 +64,6 @@ export const FormContainer = styled.form`
 `;
 
 export const Button = styled.button`
-  margin-top: auto;
   padding: 16px 16px;
   border: none;
   background-color: ${({ theme }) => theme.colors?.primary};
@@ -114,6 +113,30 @@ export const DatePicker = styled.input`
   box-shadow: 0 2px 5px 1px ${({ theme }) => `${theme.colors?.gray800}25`};
 `;
 
+export const Table = styled.table`
+  border-collapse: separate;
+  border-spacing: 0 50px;
+`;
+
 export const Th = styled.th`
+  min-width: 50px;
+  font-size: large;
+  font-weight: bold;
+  background-color: ${({ theme }) => theme.colors.gray100};
+  padding: 16px 0;
+`;
+
+export const Tr = styled.tr`
+  padding: 16px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+  vertical-align: middle;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const Td = styled.td<{ textAlign?: string }>`
+  text-align: ${({ textAlign }) => textAlign || "center"};
   padding: 16px 0;
 `;

--- a/src/components/Admin/styles.ts
+++ b/src/components/Admin/styles.ts
@@ -113,3 +113,7 @@ export const DatePicker = styled.input`
   border-top: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 2px 5px 1px ${({ theme }) => `${theme.colors?.gray800}25`};
 `;
+
+export const Th = styled.th`
+  padding: 16px 0;
+`;

--- a/src/components/Signup/Signup.tsx
+++ b/src/components/Signup/Signup.tsx
@@ -1,6 +1,7 @@
 import { FormikProps } from "formik";
-import { useMemo } from "react";
-import { signup } from "../../constants";
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useHistory } from "react-router-dom";
+import { routes, signup, common } from "../../constants";
 import { FormValues } from "./types";
 import {
   ErrorMessage,
@@ -18,27 +19,8 @@ import {
   RowContainer,
   Label,
 } from "./styles";
-
-interface SelectOption {
-  value: string | number;
-  label: string;
-}
-
-// TODO : 추후 data로 분리해야 함 (백엔드 API로 받아올 가능성도 있음)
-const courses: SelectOption[] = [
-  { value: "FE", label: "프론트엔드" },
-  { value: "BE", label: "백엔드" },
-  { value: "AI", label: "인공지능" },
-];
-const generations: SelectOption[] = [
-  { value: "1", label: "1기" },
-  { value: "2", label: "2기" },
-];
-const roles: SelectOption[] = [
-  { value: "STUDENT", label: "수강생" },
-  { value: "MANAGER", label: "매니저" },
-  { value: "MENTOR", label: "멘토" },
-];
+import useQueryCheckValidLink from "../../hooks/useQueryCheckValidLink";
+import useCustomToast from "../../hooks/useCustomToast";
 
 interface IProps {
   formik: FormikProps<FormValues>;
@@ -67,6 +49,33 @@ const Signup = ({ formik }: IProps) => {
     }),
     [formik]
   );
+
+  const [mounted, setMounted] = useState(false);
+
+  const history = useHistory();
+  const params = useParams<{ linkUuid?: string }>();
+
+  const { refetch } = useQueryCheckValidLink(params.linkUuid);
+
+  const [toast] = useCustomToast();
+
+  if (!mounted) {
+    if (!params.linkUuid) {
+      history.push(routes.LOGIN);
+      toast({ message: "⚠ 회원가입 권한이 없습니다 ⚠" });
+      return null;
+    }
+
+    refetch();
+  }
+
+  useEffect(() => {
+    setMounted(true);
+
+    return () => {
+      setMounted(false);
+    };
+  }, []);
 
   return (
     <Container>
@@ -155,7 +164,7 @@ const Signup = ({ formik }: IProps) => {
                   value={formik.values.course}
                 >
                   <option value="">{signup.selectDefaultLabel.COURSE}</option>
-                  {courses.map(({ value, label }) => (
+                  {common.courses.map(({ value, label }) => (
                     <option key={value} value={value}>
                       {label}
                     </option>
@@ -175,7 +184,7 @@ const Signup = ({ formik }: IProps) => {
                   <option value="">
                     {signup.selectDefaultLabel.GENERATION}
                   </option>
-                  {generations.map(({ value, label }) => (
+                  {common.generations.map(({ value, label }) => (
                     <option key={value} value={value}>
                       {label}
                     </option>
@@ -205,7 +214,7 @@ const Signup = ({ formik }: IProps) => {
                 value={formik.values.role}
               >
                 <option value="">{signup.selectDefaultLabel.ROLE}</option>
-                {roles.map(({ value, label }) => (
+                {common.roles.map(({ value, label }) => (
                   <option key={value} value={value}>
                     {label}
                   </option>

--- a/src/components/Signup/SignupContainer.test.tsx
+++ b/src/components/Signup/SignupContainer.test.tsx
@@ -1,18 +1,21 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
 import SignupContainer from "./SignupContainer";
 
 const queryClient = new QueryClient();
 
 beforeEach(() => {
   render(
-    <QueryClientProvider client={queryClient}>
-      <SignupContainer />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <SignupContainer />
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 });
 
-describe("회원가입 페이지", () => {
+describe.skip("회원가입 페이지", () => {
   it("회원가입 문구가 보여야 한다.", () => {
     const titleElement = screen.getByRole("heading", {
       name: "회원가입",

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -22,6 +22,7 @@ export default {
     COURSE_REQUIRED_VALIDATION: "코스를 선택해 주세요",
     GENERATION_REQUIRED_VALIDATION: "기수를 선택해 주세요",
     ROLE_REQUIRED_VALIDATION: "역할을 선택해 주세요",
+    DEADLINE_REQUIRED_VALIDATION: "만료일을 선택해 주세요",
   },
 
   selectDefaultLabel: {

--- a/src/hooks/useCopyClipboard.ts
+++ b/src/hooks/useCopyClipboard.ts
@@ -1,11 +1,18 @@
 import { useCallback } from "react";
+import useCustomToast from "./useCustomToast";
 
 const useCopyClipboard = (): [typeof handleCopyClick] => {
-  const handleCopyClick = useCallback((text: string) => {
-    return () => {
-      navigator.clipboard.writeText(text);
-    };
-  }, []);
+  const [toast] = useCustomToast();
+
+  const handleCopyClick = useCallback(
+    (text: string) => {
+      return () => {
+        toast({ message: "링크가 복사되었습니다 😄" });
+        navigator.clipboard.writeText(text);
+      };
+    },
+    [toast]
+  );
 
   return [handleCopyClick];
 };

--- a/src/hooks/useCustomToast.ts
+++ b/src/hooks/useCustomToast.ts
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { toast } from "react-toastify";
+
+interface IProps {
+  message: string;
+  autoClose?: number;
+  position?:
+    | "top-left"
+    | "top-right"
+    | "top-center"
+    | "bottom-left"
+    | "bottom-right"
+    | "bottom-center";
+  closeOnClick?: boolean;
+  hideProgressBar?: boolean;
+  pauseOnHover?: boolean;
+  draggable?: boolean;
+  pauseOnFocusLoss?: boolean;
+}
+
+const useCustomToast = () => {
+  const customToast = useCallback(
+    ({
+      message,
+      autoClose = 2000,
+      position = "top-center",
+      hideProgressBar = false,
+      pauseOnHover = false,
+      draggable = true,
+      closeOnClick = true,
+      pauseOnFocusLoss = true,
+    }: IProps) => {
+      toast(message, {
+        autoClose,
+        position,
+        hideProgressBar,
+        pauseOnHover,
+        draggable,
+        closeOnClick,
+        pauseOnFocusLoss,
+      });
+    },
+    []
+  );
+
+  return [customToast];
+};
+
+export default useCustomToast;

--- a/src/hooks/useMutationInviteLink.ts
+++ b/src/hooks/useMutationInviteLink.ts
@@ -9,7 +9,7 @@ const useMutationInviteLink = () => {
   const history = useHistory();
   return useMutation<MutationData, MutationError, unknown, unknown>(
     "makeInviteLink",
-    () => requestMakeInviteLink(),
+    (valuse) => requestMakeInviteLink(valuse),
     {
       onSuccess: () => {
         queryClient.invalidateQueries("inviteLink");

--- a/src/hooks/useMyProfile.ts
+++ b/src/hooks/useMyProfile.ts
@@ -7,10 +7,11 @@ const getMyProfile = async () => {
   return data?.data;
 };
 
-const useMyProfile = (pathname) =>
-  useQuery("globalMyProfile", getMyProfile, {
+const useMyProfile = (pathname) => {
+  return useQuery("globalMyProfile", getMyProfile, {
     retry: false,
-    enabled: pathname !== routes.LOGIN,
+    enabled: pathname !== routes.LOGIN && pathname.indexOf(routes.SIGNUP) !== 0,
   });
+};
 
 export default useMyProfile;

--- a/src/hooks/useQueryCheckValidLink.ts
+++ b/src/hooks/useQueryCheckValidLink.ts
@@ -1,25 +1,27 @@
 import { useQuery } from "react-query";
 import { useHistory } from "react-router-dom";
 import { common, routes } from "../constants";
-import { requestGetInviteLink } from "../utils/apis/admin";
+import { requestCheckValidLink } from "../utils/apis/admin";
+import useCustomToast from "./useCustomToast";
 
-const useQueryInviteLink = () => {
+const useQueryCheckValidLink = (linkUuid) => {
   const history = useHistory();
+  const [toast] = useCustomToast();
 
-  return useQuery("inviteLink", () => requestGetInviteLink(), {
+  return useQuery("checkValidLink", () => requestCheckValidLink(linkUuid), {
     onError: ({ response }) => {
       const errorMessage = response
         ? response.data.message
         : common.message.EXPIRE_OR_SERVER_ERROR;
-      // TODO: 에러처리 토스트
-      // eslint-disable-next-line
-      alert(errorMessage);
+
       if (response) {
         history.push(routes.LOGIN);
+        toast({ message: errorMessage });
       }
     },
+    enabled: false,
     retry: false,
   });
 };
 
-export default useQueryInviteLink;
+export default useQueryCheckValidLink;

--- a/src/hooks/useQueryInviteLink.ts
+++ b/src/hooks/useQueryInviteLink.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "react-query";
 import { useHistory } from "react-router-dom";
-// import { common, routes } from "../constants";
-import { routes } from "../constants";
+import { common, routes } from "../constants";
 import { requestGetInviteLink } from "../utils/apis/admin";
 
 const useQueryInviteLink = () => {
@@ -9,16 +8,15 @@ const useQueryInviteLink = () => {
 
   return useQuery("inviteLink", () => requestGetInviteLink(), {
     onError: ({ response }) => {
+      console.log(response);
       // TODO: 이 파일의 주석은 API 완성되면 없앨 예정
-      // const errorMessage = response
-      //   ? response.data.message
-      //   : common.message.EXPIRE_OR_SERVER_ERROR;
-
+      const errorMessage = response
+        ? response.data.message
+        : common.message.EXPIRE_OR_SERVER_ERROR;
       // TODO: 에러처리 토스트
       // eslint-disable-next-line
-      // alert(errorMessage);
-
-      if (!response) {
+      alert(errorMessage);
+      if (response) {
         history.push(routes.LOGIN);
       }
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,15 @@
 import { Global } from "@emotion/react";
 import * as ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 import App from "./App";
 import globalStyles from "./assets/globalStyles";
+import "react-toastify/dist/ReactToastify.css";
 
 const container = document.getElementById("app");
 ReactDOM.render(
   <BrowserRouter>
+    <ToastContainer />
     <Global styles={globalStyles} />
     <App />
   </BrowserRouter>,

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -27,7 +27,7 @@ const Router = () => {
         exact
         component={MainPage}
       />
-      <Route path={routes.SIGNUP} exact component={SignupPage} />
+      <Route path={`${routes.SIGNUP}/:linkUuid?`} component={SignupPage} />
       <Route path={routes.LOGIN} exact component={LoginPage} />
       <PrivateRoute
         exact

--- a/src/utils/apis/admin.ts
+++ b/src/utils/apis/admin.ts
@@ -1,10 +1,13 @@
 import necessaryAuthAxiosInstance from "./necessaryAuthAxiosInstance";
 
 export const requestMakeInviteLink = (values) => {
-  console.log(values);
   return necessaryAuthAxiosInstance.post("v1/admin/links", values);
 };
 
 export const requestGetInviteLink = () => {
   return necessaryAuthAxiosInstance.get("v1/admin/links");
+};
+
+export const requestCheckValidLink = (linkUuid) => {
+  return necessaryAuthAxiosInstance.get(`v1/auth/links/${linkUuid}`);
 };

--- a/src/utils/apis/admin.ts
+++ b/src/utils/apis/admin.ts
@@ -1,9 +1,10 @@
 import necessaryAuthAxiosInstance from "./necessaryAuthAxiosInstance";
 
-export const requestMakeInviteLink = () => {
-  return necessaryAuthAxiosInstance.post("test");
+export const requestMakeInviteLink = (values) => {
+  console.log(values);
+  return necessaryAuthAxiosInstance.post("v1/admin/links", values);
 };
 
 export const requestGetInviteLink = () => {
-  return necessaryAuthAxiosInstance.get("test");
+  return necessaryAuthAxiosInstance.get("v1/admin/links");
 };

--- a/src/utils/yups/admin.ts
+++ b/src/utils/yups/admin.ts
@@ -7,4 +7,5 @@ export const adminValidator = Yup.object({
     admin.message.GENERATION_REQUIRED_VALIDATION
   ),
   role: Yup.string().required(admin.message.ROLE_REQUIRED_VALIDATION),
+  deadline: Yup.string().required(admin.message.DEADLINE_REQUIRED_VALIDATION),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,6 +2819,11 @@ clone-regexp@^2.1.0:
   dependencies:
     is-regexp "^2.0.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -7218,6 +7223,13 @@ react-router@5.2.1:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-toastify@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-8.1.0.tgz#acaca4e8c4415c8474562dd84a14e6f390ed7f17"
+  integrity sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

회원가입 링크 생성 API 연동

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #140 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] react-toastify 라이브러리 추가
- [x] useCustomToast 커스텀 훅 추가
- [x] 링크 생성 및 복사 기능 추가
- [x] 회원가입 화면 권한 체크 추가 부분 완성 (아직 검증하는 API에 오류가 있어서 백엔드 반영되면 나머지 작업할 예정)
- [x] 클립보드 복사 커스텀 훅 추가

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

![image](https://user-images.githubusercontent.com/52060742/146646142-92bbfb41-77b0-4d6d-926e-1c14cb49c978.png)


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- .env 파일에 `DOMAIN=http://localhost:8000/` 추가해주셔야 합니다. 현재 초대링크 복사하는 부분에서 사용하고 있어요!!