### PR TITLE
DVT-#127내 모임 관리 페이지 API 연동

### DIFF
--- a/src/components/GatherDetail/GatherDetail.tsx
+++ b/src/components/GatherDetail/GatherDetail.tsx
@@ -32,6 +32,7 @@ import useToastUi from "../../hooks/useToastUi";
 import { MarkdownEditorWrapper } from "../MyProfile/styles";
 import ViewText from "../ViewText";
 import PeriodText from "../PeriodText";
+import { categoryColor } from "../../constants/categoryName";
 
 const GatherDetail = ({
   gatherData,
@@ -120,7 +121,7 @@ const GatherDetail = ({
             </Select>
           </EditContainer>
         ) : (
-          <Category>
+          <Category style={{ backgroundColor: categoryColor[category] }}>
             <Text size={12} color={theme.colors.white}>
               {categoryDisplayName[category]}
             </Text>

--- a/src/components/GatherDetail/styles.ts
+++ b/src/components/GatherDetail/styles.ts
@@ -20,7 +20,7 @@ export const Category = styled.div`
   width: 60px;
   height: 30px;
   line-height: 30px;
-  background-color: ${({ theme }) => theme.colors.scarlet};
+  background-color: ${({ theme }) => theme.colors.gray800};
   border-radius: 7px;
   text-align: center;
   vertical-align: middle;

--- a/src/components/GatherList/GatherList.tsx
+++ b/src/components/GatherList/GatherList.tsx
@@ -16,6 +16,7 @@ import {
   GatherLink,
 } from "./styles";
 import { categoryDisplayName, routes } from "../../constants";
+import { categoryColor } from "../../constants/categoryName";
 
 interface Props {
   selectedCategory?: string;
@@ -31,6 +32,7 @@ const GatherList = ({ selectedCategory, gatherData, page }: Props) => {
             categoryDisplayName[selectedCategory] && item.status === "GATHERING"
       )
     : gatherData?.filter((item) => item.status === "GATHERING");
+
   const finishGather = selectedCategory
     ? gatherData?.filter(
         (item) =>
@@ -39,90 +41,147 @@ const GatherList = ({ selectedCategory, gatherData, page }: Props) => {
       )
     : gatherData?.filter((item) => item.status !== "GATHERING");
 
+  if (gatherData && gatherData.length === 0) {
+    return (
+      <Text size={16} style={{ padding: "12px" }}>
+        모집이 없습니다.
+      </Text>
+    );
+  }
+
   return (
     <>
-      {gather?.map((item) => (
-        <GatherLink
-          to={`${routes.GATHERLIST}/${item.gatherId}`}
-          key={item.gatherId}
-        >
-          <ItemContainer>
-            <Category>{categoryDisplayName[item.category]}</Category>
-            <ItemDetail>
-              <TextContainer page={page}>
-                <Text ellipsisLineClamp={1}>{item.title}</Text>
-              </TextContainer>
-              <InfoWrapper page={page}>
-                <PeriodText
-                  createdDate={item.createdAt}
-                  deadLine={item.deadline}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-                <ApplicantCountText
-                  applicantCount={item.applicantCount}
-                  applicantLimit={item.applicantLimit}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-                <ViewText
-                  view={item.view}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-              </InfoWrapper>
-            </ItemDetail>
-            <ProfileBox
-              src={item.author?.profileImgUrl}
-              name={item.author.name}
-              course={item.author.course}
-              generation={item.author.generation}
-            />
-          </ItemContainer>
-        </GatherLink>
-      ))}
-      {finishGather?.map((item) => (
-        <GatherLink
-          to={`${routes.GATHERLIST}/${item.gatherId}`}
-          key={item.gatherId}
-        >
-          <FinishItemContainer>
-            <Finish page={page}>모집 마감</Finish>
-            <Category>{categoryDisplayName[item.category]}</Category>
-
-            <ItemDetail>
-              <TextContainer page={page}>
-                <Text>{item.title}</Text>
-              </TextContainer>
-              <InfoWrapper page={page}>
-                <PeriodText
-                  createdDate={item.createdAt.substring(0, 10)}
-                  deadLine={item.deadline.substring(0, 10)}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-                <ApplicantCountText
-                  applicantCount={item.applicantCount}
-                  applicantLimit={item.applicantLimit}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-                <ViewText
-                  view={item.view}
-                  iconColor={theme.colors.gray500}
-                  fontColor={theme.colors.gray600}
-                />
-              </InfoWrapper>
-            </ItemDetail>
-            <ProfileBox
-              src={item.author?.profileImgUrl}
-              name={item.author.name}
-              course={item.author.course}
-              generation={item.author.generation}
-            />
-          </FinishItemContainer>
-        </GatherLink>
-      ))}
+      {gather
+        ?.sort((a, b) => {
+          return +new Date(b.createdAt) - +new Date(a.createdAt);
+        })
+        .map((item) => (
+          <GatherLink
+            to={`${item?.gatherId ? routes.GATHERLIST : routes.MAPGAKCOLIST}/${
+              item?.gatherId ? item?.gatherId : item?.mapgakcoId
+            }`}
+            key={item?.gatherId ? item?.gatherId : item?.mapgakcoId}
+          >
+            <ItemContainer>
+              <Category
+                style={{ backgroundColor: categoryColor[item?.category] }}
+              >
+                {item?.category
+                  ? categoryDisplayName[item?.category]
+                  : "맵각코"}
+              </Category>
+              <ItemDetail>
+                <TextContainer page={page}>
+                  <Text ellipsisLineClamp={1} size={14}>
+                    {item.title}
+                  </Text>
+                </TextContainer>
+                <InfoWrapper page={page}>
+                  {item?.meetingAt ? (
+                    <PeriodText
+                      deadLine={item?.meetingAt.substring(0, 10)}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  ) : (
+                    <PeriodText
+                      createdDate={item.createdAt.substring(0, 10)}
+                      deadLine={item?.deadline.substring(0, 10)}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  )}
+                  <ApplicantCountText
+                    applicantCount={item.applicantCount}
+                    applicantLimit={item.applicantLimit}
+                    iconColor={theme.colors.gray500}
+                    fontColor={theme.colors.gray600}
+                  />
+                  {item?.view ? (
+                    <ViewText
+                      view={item?.view}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  ) : undefined}
+                </InfoWrapper>
+              </ItemDetail>
+              <ProfileBox
+                src={item.author?.profileImgUrl}
+                name={item.author.name}
+                course={item.author.course}
+                generation={item.author.generation}
+                fontSize={14}
+              />
+            </ItemContainer>
+          </GatherLink>
+        ))}
+      {finishGather
+        ?.sort((a, b) => {
+          return +new Date(b.createdAt) - +new Date(a.createdAt);
+        })
+        .map((item) => (
+          <GatherLink
+            to={`${item?.gatherId ? routes.GATHERLIST : routes.MAPGAKCOLIST}/${
+              item?.gatherId ? item?.gatherId : item?.mapgakcoId
+            }`}
+            key={item?.gatherId ? item?.gatherId : item?.mapgakcoId}
+          >
+            <FinishItemContainer>
+              <Finish page={page}>모집 마감</Finish>
+              <Category
+                style={{ backgroundColor: categoryColor[item?.category] }}
+              >
+                {item?.category
+                  ? categoryDisplayName[item?.category]
+                  : "맵각코"}
+              </Category>
+              <ItemDetail>
+                <TextContainer page={page}>
+                  <Text ellipsisLineClamp={1} size={14}>
+                    {item.title}
+                  </Text>
+                </TextContainer>
+                <InfoWrapper page={page}>
+                  {item?.meetingAt ? (
+                    <PeriodText
+                      deadLine={item?.meetingAt.substring(0, 10)}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  ) : (
+                    <PeriodText
+                      createdDate={item.createdAt.substring(0, 10)}
+                      deadLine={item?.deadline.substring(0, 10)}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  )}
+                  <ApplicantCountText
+                    applicantCount={item.applicantCount}
+                    applicantLimit={item.applicantLimit}
+                    iconColor={theme.colors.gray500}
+                    fontColor={theme.colors.gray600}
+                  />
+                  {item?.view ? (
+                    <ViewText
+                      view={item?.view}
+                      iconColor={theme.colors.gray500}
+                      fontColor={theme.colors.gray600}
+                    />
+                  ) : undefined}
+                </InfoWrapper>
+              </ItemDetail>
+              <ProfileBox
+                src={item.author?.profileImgUrl}
+                name={item.author.name}
+                course={item.author.course}
+                generation={item.author.generation}
+                fontSize={14}
+              />
+            </FinishItemContainer>
+          </GatherLink>
+        ))}
     </>
   );
 };

--- a/src/components/GatherList/styles.ts
+++ b/src/components/GatherList/styles.ts
@@ -43,7 +43,6 @@ export const FinishItemContainer = styled.div`
 export const Category = styled.div`
   background-color: ${({ theme }) => theme.colors.ultramarine};
   border-radius: 7px;
-  // padding: 12px;
   font-size: 12px;
   display: flex;
   flex-wrap: wrap;

--- a/src/components/GatherList/styles.ts
+++ b/src/components/GatherList/styles.ts
@@ -37,20 +37,27 @@ export const FinishItemContainer = styled.div`
     #ffffff;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   opacity: 80%;
-  padding: 20px;
+  padding: 16px;
 `;
 
 export const Category = styled.div`
-  background-color: ${({ theme }) => theme.colors.scarlet};
+  background-color: ${({ theme }) => theme.colors.ultramarine};
   border-radius: 7px;
-  padding: 12px;
+  // padding: 12px;
   font-size: 12px;
   display: flex;
   flex-wrap: wrap;
+  width: 70px;
+  height: 35px;
+  align-items: center;
+  justify-content: center;
+  color: white;
 
   ${gatherBreakpoints.mobile} {
     font-size: 6px;
     padding: 6px;
+    width: auto;
+    height: 35px;
   }
 `;
 

--- a/src/components/MyGather/MyGather.tsx
+++ b/src/components/MyGather/MyGather.tsx
@@ -6,8 +6,8 @@ import {
   Container,
   TitleContainer,
   GatherListContainer,
-  LargeTitleContainer,
-  MediumTitleContainer,
+  GatherContainer,
+  BothTitleContainer,
 } from "./styles";
 import { Gather } from "../../types/gather";
 import GatherList from "../GatherList/GatherList";
@@ -26,16 +26,12 @@ const MyGather = ({ applyData, makeData }: Props) => {
   const [filter, setFilter] = useState(FILTER_APPLY);
   return (
     <Container>
-      <AllContainer>
-        <TitleContainer>
-          <LargeTitleContainer>
-            <span style={{ fontSize: "30px" }}>🎈</span>
-            <Text size={20} strong>
-              신청
-            </Text>
-            <Text size={18}>한 모임</Text>
-          </LargeTitleContainer>
-          <MediumTitleContainer>
+      <Text size={24} strong>
+        내 모임 관리
+      </Text>
+      <GatherContainer>
+        <AllContainer>
+          <BothTitleContainer>
             <Button onClick={() => setFilter(FILTER_APPLY)}>
               <>
                 <span
@@ -108,27 +104,39 @@ const MyGather = ({ applyData, makeData }: Props) => {
                 </Text>
               </>
             </Button>
-          </MediumTitleContainer>
-        </TitleContainer>
-        <GatherListContainer>
-          <GatherList
-            gatherData={filter === FILTER_APPLY ? applyData : makeData}
-            page="MyGather"
-          />
-        </GatherListContainer>
-      </AllContainer>
-      <MakeContainer>
-        <TitleContainer>
-          <span style={{ fontSize: "30px" }}>🚩</span>
-          <Text size={20} strong>
-            개설
-          </Text>
-          <Text size={18}>한 모임</Text>
-        </TitleContainer>
-        <GatherListContainer>
-          <GatherList gatherData={makeData} page="MyGather" />
-        </GatherListContainer>
-      </MakeContainer>
+          </BothTitleContainer>
+          <GatherListContainer>
+            <GatherList
+              gatherData={filter === FILTER_APPLY ? applyData : makeData}
+              page="MyGather"
+            />
+          </GatherListContainer>
+        </AllContainer>
+        <MakeContainer>
+          <TitleContainer>
+            <span style={{ fontSize: "30px" }}>🚩</span>
+            <Text size={20} strong>
+              신청
+            </Text>
+            <Text size={18}>한 모임</Text>
+          </TitleContainer>
+          <GatherListContainer>
+            <GatherList gatherData={applyData} page="MyGather" />
+          </GatherListContainer>
+        </MakeContainer>
+        <MakeContainer>
+          <TitleContainer>
+            <span style={{ fontSize: "30px" }}>🚩</span>
+            <Text size={20} strong>
+              등록
+            </Text>
+            <Text size={18}>한 모임</Text>
+          </TitleContainer>
+          <GatherListContainer>
+            <GatherList gatherData={makeData} page="MyGather" />
+          </GatherListContainer>
+        </MakeContainer>
+      </GatherContainer>
     </Container>
   );
 };

--- a/src/components/MyGather/MyGatherContainer.tsx
+++ b/src/components/MyGather/MyGatherContainer.tsx
@@ -10,7 +10,7 @@ const MyGatherContainer = () => {
     <div>
       {applyData && makeData ? (
         <MyGather applyData={applyData} makeData={makeData} />
-      ) : undefined}
+      ) : null}
     </div>
   );
 };

--- a/src/components/MyGather/MyGatherContainer.tsx
+++ b/src/components/MyGather/MyGatherContainer.tsx
@@ -1,144 +1,18 @@
 import MyGather from "./MyGather";
-
-export const dummy = [
-  {
-    status: "GATHERING",
-    gatherId: 1,
-    category: "PROJECT",
-    title: "아침까지 달리는 프로젝트 모집한다구요",
-    createdAt: "2021-12-04",
-    deadline: "2021-12-11",
-    applicantLimit: 8,
-    applicantCount: 3,
-    view: 67,
-    isApplied: false,
-    commentCount: 0,
-    author: {
-      userId: 1,
-      name: "뿡조",
-      course: "BE",
-      generation: 2,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-    },
-  },
-  {
-    status: "CLOSED",
-    gatherId: 2,
-    category: "STUDY",
-    title: "백준 플래1에게 배우는 알고리즘 스터디 모집한다구요",
-    createdAt: "2021-11-04",
-    deadline: "2021-11-23",
-    applicantLimit: 4,
-    applicantCount: 4,
-    isApplied: false,
-    commentCount: 0,
-    view: 5138,
-    author: {
-      name: "뿡찬",
-      course: "FE",
-      generation: 1,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-      userId: 7,
-    },
-  },
-  {
-    status: "GATHERING",
-    gatherId: 3,
-    category: "CLUB",
-    title: "닭발 매니아 모집한다구요~~~",
-    createdAt: "2021-10-04",
-    deadline: "2021-10-23",
-    applicantLimit: 15,
-    applicantCount: 4,
-    view: 32,
-    isApplied: false,
-    commentCount: 0,
-    author: {
-      name: "뿡민이",
-      course: "BE",
-      generation: 5,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-      userId: 2,
-    },
-  },
-  {
-    status: "GATHERING",
-    gatherId: 4,
-    category: "STUDY",
-    title: "Git 스터디 모집한다구요~~~",
-    createdAt: "2022-01-04",
-    deadline: "2022-01-08",
-    applicantLimit: 4,
-    applicantCount: 2,
-    view: 150,
-    isApplied: false,
-    commentCount: 0,
-    author: {
-      name: "뿡철이",
-      course: "FE",
-      generation: 5,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-      userId: 2,
-    },
-  },
-  {
-    status: "GATHERING",
-    gatherId: 5,
-    category: "CLUB",
-    title: "해안도로 제주도 드라이브 투게더 모집한다구요~~~",
-    createdAt: "2021-12-04",
-    deadline: "2021-12-23",
-    applicantLimit: 6,
-    applicantCount: 6,
-    view: 340,
-    isApplied: false,
-    commentCount: 0,
-    author: {
-      name: "뿡름이",
-      course: "FE",
-      generation: 5,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-      userId: 2,
-    },
-  },
-  {
-    status: "GATHERING",
-    gatherId: 6,
-    category: "CLUB",
-    title: "건강 음료 시식회 모집한다구요~~~",
-    createdAt: "2021-12-04",
-    deadline: "2021-12-32",
-    applicantLimit: 6,
-    applicantCount: 0,
-    view: 3,
-    isApplied: false,
-    commentCount: 0,
-    author: {
-      name: "뿡크",
-      course: "BE",
-      generation: 2,
-      profileImgUrl: "https://picsum.photos/200/400",
-      role: "STUDENT",
-      userId: 2,
-    },
-  },
-];
+import useMyPostingGather from "../../hooks/useMyPostingGather";
+import useMyAppliedGather from "../../hooks/useMyAppliedGather";
 
 const MyGatherContainer = () => {
-  // TODO : 내가 등록한 목록을 가져올 API호출 -> MyGather의 gatherData로 넘겨줄 값을 반환 (현재 dummy데이터로 처리)
-  // GET /api/v1/users/me/host
-  // 변수 이름: applyData
+  const { data: makeData } = useMyPostingGather();
+  const { data: applyData } = useMyAppliedGather();
 
-  // TODO : 내가 신청한 목록을 가져올 API호출
-  // GET /api/v1/users/me/applicant
-  // 변수 이름: registerData
-
-  return <MyGather applyData={dummy} makeData={dummy} />;
+  return (
+    <div>
+      {applyData && makeData ? (
+        <MyGather applyData={applyData} makeData={makeData} />
+      ) : undefined}
+    </div>
+  );
 };
 
 export default MyGatherContainer;

--- a/src/components/MyGather/styles.ts
+++ b/src/components/MyGather/styles.ts
@@ -3,8 +3,9 @@ import { breakpoints } from "../../assets/media";
 
 export const Container = styled.div`
   display: flex;
-  gap: 36px;
-  padding: 40px 0 20px 20px;
+  flex-direction: column;
+  padding-top: 30px;
+  padding: 30px 20px;
 `;
 
 export const AllContainer = styled.div`
@@ -18,6 +19,10 @@ export const AllContainer = styled.div`
   border-radius: 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 2px 5px 1px ${({ theme }) => `${theme.colors?.gray800}25`};
+
+  ${breakpoints.minDesktop} {
+    display: none;
+  }
 `;
 
 export const MakeContainer = styled.div`
@@ -42,25 +47,9 @@ export const TitleContainer = styled.div`
   flex-direction: row;
   align-items: baseline;
   padding: 12px;
-`;
 
-export const LargeTitleContainer = styled.div`
-  ${breakpoints.maxTablet} {
-    display: none;
-  }
-`;
-
-export const MediumTitleContainer = styled.div`
-  display: none;
-
-  ${breakpoints.maxTablet} {
-    display: flex;
-    flex-direction: row;
-    gap: 16px;
-
-    button {
-      align-items: baseline;
-    }
+  button {
+    align-items: baseline;
   }
 `;
 
@@ -68,4 +57,23 @@ export const GatherListContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
+`;
+
+export const GatherContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 36px;
+  padding: 20px 0;
+`;
+
+export const BothTitleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  padding: 12px;
+  gap: 20px;
+
+  button {
+    align-items: baseline;
+  }
 `;

--- a/src/components/PeriodText/index.tsx
+++ b/src/components/PeriodText/index.tsx
@@ -3,7 +3,7 @@ import { BsFillCalendar2EventFill } from "react-icons/bs";
 import Text from "../base/Text";
 
 interface Props {
-  createdDate: string;
+  createdDate?: string;
   deadLine: string;
   iconSize?: string | number;
   iconColor?: string;
@@ -28,10 +28,16 @@ const PeriodText = ({
   return (
     <Container>
       <BsFillCalendar2EventFill size={iconSize} color={iconColor} />
-      <Text
-        size={fontSize}
-        color={fontColor}
-      >{`${createdDate}~${deadLine}`}</Text>
+      {createdDate ? (
+        <Text
+          size={fontSize}
+          color={fontColor}
+        >{`${createdDate} ~ ${deadLine}`}</Text>
+      ) : (
+        <Text size={fontSize} color={fontColor}>
+          {deadLine}
+        </Text>
+      )}
     </Container>
   );
 };

--- a/src/components/ProfileBox/ProfileBox.tsx
+++ b/src/components/ProfileBox/ProfileBox.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { breakpoints, gatherBreakpoints } from "../../assets/media";
 import theme from "../../assets/theme";
+import { common } from "../../constants";
 import Text from "../base/Text";
 
 interface Props {
@@ -53,7 +54,7 @@ export const InfoWrapper = styled.div`
 `;
 
 const ProfileBox = ({
-  src,
+  src = common.placeHolderImageSrc,
   size,
   alt,
   fontSize,
@@ -63,7 +64,7 @@ const ProfileBox = ({
 }: Props) => {
   return (
     <ProfileBoxWrapper>
-      {src && <Image src={src} alt={alt} size={size} />}
+      <Image src={src || common.placeHolderImageSrc} alt={alt} size={size} />
       <Text size={fontSize}>{name}</Text>
       <InfoWrapper>
         <Text size={fontSize - 2} color={theme.colors.white}>

--- a/src/constants/categoryName.ts
+++ b/src/constants/categoryName.ts
@@ -13,7 +13,7 @@ export const categoryValue = {
 };
 
 export const categoryColor = {
-  STUDY: theme.colors.skyblue,
-  PROJECT: theme.colors.coral,
-  CLUB: theme.colors.olive,
+  STUDY: theme?.colors?.skyblue,
+  PROJECT: theme?.colors?.coral,
+  CLUB: theme?.colors?.olive,
 };

--- a/src/constants/categoryName.ts
+++ b/src/constants/categoryName.ts
@@ -1,3 +1,5 @@
+import theme from "../assets/theme";
+
 export const categoryDisplayName = {
   STUDY: "스터디",
   PROJECT: "프로젝트",
@@ -8,4 +10,10 @@ export const categoryValue = {
   STUDY: "STUDY",
   PROJECT: "PROJECT",
   CLUB: "CLUB",
+};
+
+export const categoryColor = {
+  STUDY: theme.colors.skyblue,
+  PROJECT: theme.colors.coral,
+  CLUB: theme.colors.olive,
 };

--- a/src/hooks/useMyAppliedGather.ts
+++ b/src/hooks/useMyAppliedGather.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "react-query";
+import { requestGetMyAppliedGather } from "../utils/apis/gather";
+
+const getMyGather = async () => {
+  const { data } = await requestGetMyAppliedGather();
+  const gathers = data?.data.gathers;
+  const mapgakcos = data?.data.mapgakcos;
+  return [...gathers, ...mapgakcos];
+};
+
+const useMyAppliedGather = () => {
+  return useQuery(["myAppliedGather"], () => getMyGather());
+};
+
+export default useMyAppliedGather;

--- a/src/hooks/useMyPostingGather.ts
+++ b/src/hooks/useMyPostingGather.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "react-query";
+import { requestGetMyCreatedGather } from "../utils/apis/gather";
+
+const getMyGather = async () => {
+  const { data } = await requestGetMyCreatedGather();
+  const gathers = data?.data.gathers;
+  const mapgakcos = data?.data.mapgakcos;
+  return [...gathers, ...mapgakcos];
+};
+
+const useMyPostingGather = () => {
+  return useQuery(["myPostingGather"], () => getMyGather());
+};
+
+export default useMyPostingGather;

--- a/src/types/gather.ts
+++ b/src/types/gather.ts
@@ -2,20 +2,45 @@ import { Comment } from "./comment";
 import { SimpleUserInfo } from "./simpleUserInfo";
 
 export interface Gather {
-  gatherId: number;
+  gatherId?: number;
   status: string;
   title: string;
   content?: string;
-  category: string;
-  deadline: string;
+  category?: string;
+  deadline?: string;
   createdAt: string;
   modifiedAt?: string;
   author: SimpleUserInfo;
   applicantLimit: number;
-  view: number;
+  view?: number;
   applicantCount: number;
-  commentCount: number;
-  isApplied: boolean;
+  commentCount?: number;
+  isApplied?: boolean;
   participants?: Array<SimpleUserInfo>;
+  comments?: Array<Comment>;
+
+  mapgakcoId?: number;
+  location?: string;
+  latitude?: number;
+  longitude?: number;
+  meetingAt?: string;
+}
+
+export interface Mapgakco {
+  mapgakcoId: number;
+  applicantLimit: number;
+  applicantCount: number;
+  status: string;
+  title: string;
+  content: string;
+  location: string;
+  latitude: number;
+  longitude: number;
+  meetingAt: number;
+  createdAt: number;
+  modifiedAt?: number;
+
+  author: SimpleUserInfo;
+  applicants?: Array<SimpleUserInfo>;
   comments?: Array<Comment>;
 }

--- a/src/utils/apis/gather.ts
+++ b/src/utils/apis/gather.ts
@@ -63,3 +63,11 @@ export const requestEditGatherDetail = (editValue) => {
 export const requestCloseGather = (gatherId) => {
   return necessaryAuthAxiosInstance.patch(`v1/gathers/${gatherId}/close`);
 };
+
+export const requestGetMyCreatedGather = () => {
+  return necessaryAuthAxiosInstance.get("v1/users/me/host");
+};
+
+export const requestGetMyAppliedGather = () => {
+  return necessaryAuthAxiosInstance.get("v1/users/me/applicant");
+};


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

내 모임 관리 페이지에 필요한 API들을 연동한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #127

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 내가 모집한 모임 API 연동
- [x] 내가 신청한 모임 API 연동

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

**내 모임 관리 페이지**
![image](https://user-images.githubusercontent.com/55550034/146654517-c6fde1ba-7048-4d72-a26c-4ca5231b199b.png)

**창이 줄었을 때**
![image](https://user-images.githubusercontent.com/55550034/146654554-f2613605-47b6-4ff6-9eaf-475a15e2c48f.png)


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 내 모집을 보여줄 때 맵각코도 같이 보여주기 때문에 맵각코 속성들을 gather에 추가했습니다
- 기존에 내 모임 관리 페이지의 반응형을 위해 만든 구조에 문제가 있어서 수정했습니다
   - 창이 줄었을 때 등록한 모임을 클릭했다가 창이 늘어나면 신청한 모임에 등록한 모임의 리스트가 뜨는 문제였습니다
- 개설 -> 등록으로 명칭 수정
- 유저 디폴트 이미지 추가
- 가시성을 위해 모집기간에 공백 추가
- 내 모임 관리 페이지 타이틀
