### PR TITLE
DVT-#115 맵각코 페이지 맵각코 조회 기능 추가

### DIFF
--- a/fixtures/userInfo.ts
+++ b/fixtures/userInfo.ts
@@ -45,8 +45,8 @@ const randomUserInfo = (): UserInfo => ({
     blogUrl: faker.internet.url(),
     githubUrl: faker.internet.url(),
     summary: faker.lorem.sentence(),
-    latitude: +faker.address.longitude(37.597846162982, 37.469538697168495),
-    longitude: +faker.address.latitude(127.13984731519888, 126.9253883715795),
+    latitude: +faker.address.latitude(37.597846162982, 37.469538697168495),
+    longitude: +faker.address.longitude(127.13984731519888, 126.9253883715795),
     createdAt: faker.datatype.datetime(),
     updatedAt: faker.datatype.datetime(),
 

--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -5,6 +5,7 @@ const theme = {
     primary: "#ffb266",
     fontColor: "#4d5256",
     disabled: "#c0c0c0",
+    markerBlue: "#0472E7",
     black: "#000",
     white: "#fff",
     orange100: "#ffd9b3",

--- a/src/components/Mapbox/Mapbox.tsx
+++ b/src/components/Mapbox/Mapbox.tsx
@@ -36,7 +36,6 @@ interface Props {
   children?: ReactNode;
   // eslint-disable-next-line @typescript-eslint/ban-types
   onCenterChanged?: Function;
-  removeImageMarkerOverlays?: boolean;
   onClick?: (
     target: kakao.maps.Map,
     mouseEvent: kakao.maps.event.MouseEvent
@@ -57,12 +56,11 @@ const Mapbox = ({
   style,
   children,
   onCenterChanged,
-  removeImageMarkerOverlays = false,
   onClick,
 }: Props) => {
   const memoMap = useRef(null);
   const memoImageMarkerOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
-  const memoMapgakcoOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
+  const memoMapgakcos = useRef<kakao.maps.CustomOverlay[]>([]);
 
   const MapStyle = {
     width: "100%",
@@ -73,6 +71,18 @@ const Mapbox = ({
   const handleCreate = useCallback(
     (map: kakao.maps.Map) => {
       memoMap.current = map;
+
+      memoImageMarkerOverlays.current.forEach((overlay) => {
+        removeOverlay(overlay);
+      });
+
+      memoImageMarkerOverlays.current = [];
+
+      memoMapgakcos.current.forEach((overlay) => {
+        removeOverlay(overlay);
+      });
+
+      memoMapgakcos.current = [];
 
       if (hasControl) {
         addControl(map);
@@ -86,32 +96,14 @@ const Mapbox = ({
         addImageMarker({ map, position, imageUrl });
       });
 
-      if (removeImageMarkerOverlays) {
-        memoImageMarkerOverlays.current.forEach((overlay) => {
-          removeOverlay(overlay);
-        });
-
-        memoImageMarkerOverlays.current = [];
-      }
-
       imageMarkerOverlays.forEach(({ position, imageUrl, options }) => {
         memoImageMarkerOverlays.current.push(
           addImageMarkerOverlay({ map, position, imageUrl, options })
         );
       });
 
-      if (removeImageMarkerOverlays) {
-        memoImageMarkerOverlays.current.forEach((overlay) => {
-          removeOverlay(overlay);
-        });
-
-        memoImageMarkerOverlays.current = [];
-      }
-
       mapgakcos.forEach((mapgakco) => {
-        memoMapgakcoOverlays.current.push(
-          addMapgakcoOverlay({ map, mapgakco })
-        );
+        memoMapgakcos.current.push(addMapgakcoOverlay({ map, mapgakco }));
       });
 
       hasCenterMarker &&
@@ -132,7 +124,6 @@ const Mapbox = ({
       keyword,
       mapgakcos,
       markers,
-      removeImageMarkerOverlays,
       userImageUrl,
     ]
   );

--- a/src/components/Mapbox/Mapbox.tsx
+++ b/src/components/Mapbox/Mapbox.tsx
@@ -3,6 +3,7 @@ import { Map } from "react-kakao-maps-sdk";
 import {
   ImageMarker,
   ImageMarkerOverlay,
+  Mapgakco,
   Marker,
   Position,
 } from "../../types/mapTypes";
@@ -13,21 +14,24 @@ import {
   addMarkerFromPosition,
   removeOverlay,
 } from "../../utils/map";
+import { addMapgakcoOverlay } from "../../utils/map/overlay";
 import { keywordSearch } from "../../utils/map/place";
 
 import "./customOverlayMarker.scss";
 import "./imageMarker.scss";
+import "./mapgakcoOverlay.scss";
 
 interface Props {
   center: Position;
   isPanto?: boolean;
+  hasControl?: boolean;
   hasCenterMarker?: boolean;
+  userImageUrl?: string;
+  keyword?: string;
   markers?: Marker[];
   imageMarkers?: ImageMarker[];
   imageMarkerOverlays?: ImageMarkerOverlay[];
-  hasControl?: boolean;
-  userImageUrl?: string;
-  keyword?: string;
+  mapgakcos?: Mapgakco[];
   style?: React.CSSProperties;
   children?: ReactNode;
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -42,13 +46,14 @@ interface Props {
 const Mapbox = ({
   center,
   isPanto = false,
+  hasControl = true,
   hasCenterMarker = false,
+  userImageUrl = "",
+  keyword = "",
   markers = [],
   imageMarkers = [],
   imageMarkerOverlays = [],
-  hasControl = true,
-  userImageUrl = "",
-  keyword = "",
+  mapgakcos = [],
   style,
   children,
   onCenterChanged,
@@ -57,6 +62,7 @@ const Mapbox = ({
 }: Props) => {
   const memoMap = useRef(null);
   const memoImageMarkerOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
+  const memoMapgakcoOverlays = useRef<kakao.maps.CustomOverlay[]>([]);
 
   const MapStyle = {
     width: "100%",
@@ -94,6 +100,20 @@ const Mapbox = ({
         );
       });
 
+      if (removeImageMarkerOverlays) {
+        memoImageMarkerOverlays.current.forEach((overlay) => {
+          removeOverlay(overlay);
+        });
+
+        memoImageMarkerOverlays.current = [];
+      }
+
+      mapgakcos.forEach((mapgakco) => {
+        memoMapgakcoOverlays.current.push(
+          addMapgakcoOverlay({ map, mapgakco })
+        );
+      });
+
       hasCenterMarker &&
         addImageMarkerOverlay({
           map,
@@ -110,6 +130,7 @@ const Mapbox = ({
       imageMarkerOverlays,
       imageMarkers,
       keyword,
+      mapgakcos,
       markers,
       removeImageMarkerOverlays,
       userImageUrl,

--- a/src/components/Mapbox/mapgakcoOverlay.scss
+++ b/src/components/Mapbox/mapgakcoOverlay.scss
@@ -1,3 +1,5 @@
+$marker--blue-color: #0472E7;
+
 .mapgakco {
   display: flex;
   flex-direction: column;
@@ -50,4 +52,50 @@
     top: -0.1em;
     vertical-align: middle;
   }
+}
+
+.customoverlay {
+  position: relative;
+  bottom: 85px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  border-bottom: 2px solid #ddd;
+  float: left;
+}
+.customoverlay:nth-of-type(n) {
+  border: 0;
+  box-shadow: 0px 1px 2px #888;
+}
+.customoverlay a {
+  display: block;
+  text-decoration: none;
+  color: #000;
+  text-align: center;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: bold;
+  overflow: hidden;
+  background: $marker--blue-color;
+  background: $marker--blue-color
+    url(https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/arrow_white.png)
+    no-repeat right 14px center;
+}
+.customoverlay .title {
+  display: block;
+  text-align: center;
+  background: #fff;
+  margin-right: 35px;
+  padding: 10px 15px;
+  font-size: 14px;
+  font-weight: bold;
+}
+.customoverlay:after {
+  content: "";
+  position: absolute;
+  margin-left: -12px;
+  left: 50%;
+  bottom: -12px;
+  width: 22px;
+  height: 12px;
+  background: url("https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/vertex_white.png");
 }

--- a/src/components/Mapbox/mapgakcoOverlay.scss
+++ b/src/components/Mapbox/mapgakcoOverlay.scss
@@ -1,0 +1,53 @@
+.mapgakco {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #ed1c40;
+  padding: 6px;
+  border-radius: 10px;
+  color: white;
+  white-space: nowrap;
+
+  .mapgakco__header {
+    .mapgakco__status {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.7);
+      font-weight: 400;
+      font-size: 10px;
+      line-height: 1.4;
+      text-transform: uppercase;
+    }
+  }
+
+  .mapgakco__section {
+    display: flex;
+    flex-direction: column;
+
+    .mapgakco__title {
+      color: #fff;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1;
+      text-decoration: none;
+    }
+
+    .mapgakco__list {
+      padding-left: 6px;
+
+      .mapgakco__row {
+        font-size: 10px;
+        margin-top: 4px;
+
+        .mapgakco__rowItem {
+          padding-left: 10px;
+        }
+      }
+    }
+  }
+
+  .icon {
+    display: inline-block;
+    position: relative;
+    top: -0.1em;
+    vertical-align: middle;
+  }
+}

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { BsCalendarDate, BsPeople, BsPinMap } from "react-icons/bs";
 import useClickAway from "../../../hooks/useClickAway";
 import useToastUi from "../../../hooks/useToastUi";
@@ -45,68 +45,52 @@ const MapgakcoDetail = ({
     onModalClose();
   });
 
+  const handleMarkdownChange = useCallback((markdownInnerText) => {
+    setContent(markdownInnerText);
+  }, []);
+
   if (!mapgakco) {
     return null;
   }
-
-  const {
-    status = "",
-    title = "",
-    location = "",
-    meetingAt = "",
-    applicantLimit = 0,
-    applicantCount = 0,
-    author = {
-      name: "",
-      course: "",
-      generation: 0,
-      role: "",
-      profileImgUrl: "",
-    },
-  } = mapgakco;
-
-  const {
-    name = "",
-    course = "",
-    generation = "",
-    role = "",
-    profileImgUrl = "",
-  } = author;
 
   return (
     <Container ref={ref}>
       <Card>
         <div className="poster">
-          <h2 className="location">{status}</h2>
-          <h1 className="title">{title}</h1>
+          <h2 className="status">{mapgakco?.status}</h2>
+          <h1 className="title">{mapgakco?.title}</h1>
           <p className="details">
             <span className="row">
               <BsCalendarDate />
               <span className="row-item">
-                {koreanDate(new Date(meetingAt))}
+                {koreanDate(new Date(mapgakco?.meetingAt))}
               </span>
             </span>
             <span className="row">
               <BsPinMap />
               <span className="row-item">
-                <strong>상세 장소</strong>
+                <strong>{mapgakco?.location}</strong>
               </span>
             </span>
             <span className="row">
               <BsPeople />
               <span className="row-item">
-                <strong>4 / 6 명</strong>
+                <strong>
+                  {mapgakco?.applicantCount} / {mapgakco?.applicantLimit} 명
+                </strong>
               </span>
             </span>
           </p>
         </div>
       </Card>
       <MarkdownEditorWrapper>
+        {/* 신청자 */}
+        {/* <MarkdownEditor isViewMode editorRef={editorRef} value={content} /> */}
         <MarkdownEditor
           isViewMode={false}
           editorRef={editorRef}
           value={content}
-          setEditorText={() => ({})}
+          setEditorText={handleMarkdownChange}
         />
       </MarkdownEditorWrapper>
     </Container>

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -1,16 +1,25 @@
 import { useState } from "react";
 import { BsCalendarDate, BsPeople, BsPinMap } from "react-icons/bs";
+import useClickAway from "../../../hooks/useClickAway";
 import useToastUi from "../../../hooks/useToastUi";
 import MarkdownEditor from "../../base/MarkdownEditor";
 import { Card, Container, MarkdownEditorWrapper } from "./styles";
 
-const MapgakcoDetail = () => {
+interface Props {
+  onClose: () => void;
+}
+
+const MapgakcoDetail = ({ onClose }: Props) => {
   const [editorRef] = useToastUi();
 
   const [content, setContent] = useState("markdown content");
 
+  const ref = useClickAway(() => {
+    onClose();
+  });
+
   return (
-    <Container>
+    <Container ref={ref}>
       <Card>
         <div className="poster">
           <h2 className="location">GATHERING</h2>

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -6,16 +6,16 @@ import MarkdownEditor from "../../base/MarkdownEditor";
 import { Card, Container, MarkdownEditorWrapper } from "./styles";
 
 interface Props {
-  onClose: () => void;
+  onModalClose: () => void;
 }
 
-const MapgakcoDetail = ({ onClose }: Props) => {
+const MapgakcoDetail = ({ onModalClose }: Props) => {
   const [editorRef] = useToastUi();
 
   const [content, setContent] = useState("markdown content");
 
   const ref = useClickAway(() => {
-    onClose();
+    onModalClose();
   });
 
   return (
@@ -43,14 +43,14 @@ const MapgakcoDetail = ({ onClose }: Props) => {
             </span>
           </p>
         </div>
-        <MarkdownEditorWrapper>
-          <MarkdownEditor
-            isViewMode={false}
-            editorRef={editorRef}
-            value={content}
-          />
-        </MarkdownEditorWrapper>
       </Card>
+      <MarkdownEditorWrapper>
+        <MarkdownEditor
+          isViewMode={false}
+          editorRef={editorRef}
+          value={content}
+        />
+      </MarkdownEditorWrapper>
     </Container>
   );
 };

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -4,12 +4,39 @@ import useClickAway from "../../../hooks/useClickAway";
 import useToastUi from "../../../hooks/useToastUi";
 import MarkdownEditor from "../../base/MarkdownEditor";
 import { Card, Container, MarkdownEditorWrapper } from "./styles";
+import { Mapgakco } from "../../../types/mapTypes";
+import { koreanDate } from "../../../utils/date";
 
 interface Props {
+  mapgakco: Mapgakco;
   onModalClose: () => void;
 }
 
-const MapgakcoDetail = ({ onModalClose }: Props) => {
+const initialMapgakco: Mapgakco = {
+  mapgakcoId: 37,
+  status: "GATHERING",
+  title: "맵각코",
+  location: "맵각코 위치",
+  meetingAt: "2021-12-18T23:51:34",
+  latitude: 37.58009056466645,
+  longitude: 126.9228016641275,
+  applicantLimit: 5,
+  applicantCount: 1,
+  createdAt: "2021-12-18T23:51:34",
+  author: {
+    userId: 54,
+    name: "dummy1",
+    course: "FE",
+    generation: 1,
+    profileImgUrl: null,
+    role: "STUDENT",
+  },
+};
+
+const MapgakcoDetail = ({
+  mapgakco = initialMapgakco,
+  onModalClose,
+}: Props) => {
   const [editorRef] = useToastUi();
 
   const [content, setContent] = useState("markdown content");
@@ -18,16 +45,46 @@ const MapgakcoDetail = ({ onModalClose }: Props) => {
     onModalClose();
   });
 
+  if (!mapgakco) {
+    return null;
+  }
+
+  const {
+    status = "",
+    title = "",
+    location = "",
+    meetingAt = "",
+    applicantLimit = 0,
+    applicantCount = 0,
+    author = {
+      name: "",
+      course: "",
+      generation: 0,
+      role: "",
+      profileImgUrl: "",
+    },
+  } = mapgakco;
+
+  const {
+    name = "",
+    course = "",
+    generation = "",
+    role = "",
+    profileImgUrl = "",
+  } = author;
+
   return (
     <Container ref={ref}>
       <Card>
         <div className="poster">
-          <h2 className="location">GATHERING</h2>
-          <h1 className="title">자바스크립트 스터디</h1>
+          <h2 className="location">{status}</h2>
+          <h1 className="title">{title}</h1>
           <p className="details">
             <span className="row">
               <BsCalendarDate />
-              <span className="row-item">12월 28일 11PM</span>
+              <span className="row-item">
+                {koreanDate(new Date(meetingAt))}
+              </span>
             </span>
             <span className="row">
               <BsPinMap />
@@ -49,6 +106,7 @@ const MapgakcoDetail = ({ onModalClose }: Props) => {
           isViewMode={false}
           editorRef={editorRef}
           value={content}
+          setEditorText={() => ({})}
         />
       </MarkdownEditorWrapper>
     </Container>

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -3,9 +3,11 @@ import { BsCalendarDate, BsPeople, BsPinMap } from "react-icons/bs";
 import useClickAway from "../../../hooks/useClickAway";
 import useToastUi from "../../../hooks/useToastUi";
 import MarkdownEditor from "../../base/MarkdownEditor";
-import { Card, Container, MarkdownEditorWrapper } from "./styles";
+import { Card, Container, Footer, MarkdownEditorWrapper } from "./styles";
 import { Mapgakco } from "../../../types/mapTypes";
 import { koreanDate } from "../../../utils/date";
+import Button from "../../base/Button";
+import theme from "../../../assets/theme";
 
 interface Props {
   mapgakco: Mapgakco;
@@ -48,6 +50,29 @@ const MapgakcoDetail = ({
   const handleMarkdownChange = useCallback((markdownInnerText) => {
     setContent(markdownInnerText);
   }, []);
+
+  const defaultButtonStyle = {
+    padding: "8px",
+    minWidth: "80px",
+    width: "100%",
+    display: "flex",
+    justifyContent: "center",
+    borderRadius: "8px",
+
+    boxShadow: theme.boxShadows.primary,
+  };
+
+  const activeButtonStyle = {
+    ...defaultButtonStyle,
+    color: theme.colors.white,
+    backgroundColor: theme.colors.markerBlue,
+  };
+
+  const inactiveButtonStyle = {
+    ...defaultButtonStyle,
+    color: theme.colors.white,
+    backgroundColor: theme.colors.disabled,
+  };
 
   if (!mapgakco) {
     return null;
@@ -93,6 +118,14 @@ const MapgakcoDetail = ({
           setEditorText={handleMarkdownChange}
         />
       </MarkdownEditorWrapper>
+      <Footer>
+        <Button style={activeButtonStyle} onClick={() => ({})}>
+          신청
+        </Button>
+        <Button style={inactiveButtonStyle} onClick={() => ({})}>
+          신청 취소
+        </Button>
+      </Footer>
     </Container>
   );
 };

--- a/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
+++ b/src/components/MapgakcoMap/MapgakcoDetail/index.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { BsCalendarDate, BsPeople, BsPinMap } from "react-icons/bs";
+import useToastUi from "../../../hooks/useToastUi";
+import MarkdownEditor from "../../base/MarkdownEditor";
+import { Card, Container, MarkdownEditorWrapper } from "./styles";
+
+const MapgakcoDetail = () => {
+  const [editorRef] = useToastUi();
+
+  const [content, setContent] = useState("markdown content");
+
+  return (
+    <Container>
+      <Card>
+        <div className="poster">
+          <h2 className="location">GATHERING</h2>
+          <h1 className="title">자바스크립트 스터디</h1>
+          <p className="details">
+            <span className="row">
+              <BsCalendarDate />
+              <span className="row-item">12월 28일 11PM</span>
+            </span>
+            <span className="row">
+              <BsPinMap />
+              <span className="row-item">
+                <strong>상세 장소</strong>
+              </span>
+            </span>
+            <span className="row">
+              <BsPeople />
+              <span className="row-item">
+                <strong>4 / 6 명</strong>
+              </span>
+            </span>
+          </p>
+        </div>
+        <MarkdownEditorWrapper>
+          <MarkdownEditor
+            isViewMode={false}
+            editorRef={editorRef}
+            value={content}
+          />
+        </MarkdownEditorWrapper>
+      </Card>
+    </Container>
+  );
+};
+
+export default MapgakcoDetail;

--- a/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
+++ b/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
@@ -9,7 +9,7 @@ export const Container = styled.div`
 `;
 
 export const Card = styled.div`
-  background: #ed1c40;
+  background: ${({ theme }) => theme.colors.markerBlue};
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -56,4 +56,10 @@ export const Card = styled.div`
 
 export const MarkdownEditorWrapper = styled.div`
   flex-grow: 1;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
 `;

--- a/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
+++ b/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
@@ -1,0 +1,59 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+`;
+
+export const Card = styled.div`
+  flex-grow: 1;
+  background: #ed1c40;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 16px;
+  border-radius: 10px;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  .poster {
+    h2 {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.7);
+      font-weight: 400;
+      font-size: 18px;
+      line-height: 2;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+
+    h1 {
+      font-size: 24px;
+      font-weight: 700;
+      line-height: 1;
+      text-decoration: none;
+      padding: 6px 0;
+    }
+
+    .details {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .row {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      margin-top: 10px;
+    }
+
+    .row-item {
+      padding-left: 10px;
+    }
+  }
+`;
+
+export const MarkdownEditorWrapper = styled.div`
+  flex-grow: 1;
+`;

--- a/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
+++ b/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
@@ -3,12 +3,12 @@ import styled from "@emotion/styled";
 export const Container = styled.div`
   flex-grow: 1;
   display: flex;
+  gap: 10px;
   flex-direction: column;
   padding: 8px;
 `;
 
 export const Card = styled.div`
-  flex-grow: 1;
   background: #ed1c40;
   display: flex;
   flex-direction: column;

--- a/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
+++ b/src/components/MapgakcoMap/MapgakcoDetail/styles.ts
@@ -19,7 +19,7 @@ export const Card = styled.div`
   color: ${({ theme }) => theme.colors.white};
 
   .poster {
-    h2 {
+    .status {
       border-bottom: 1px solid rgba(255, 255, 255, 0.7);
       font-weight: 400;
       font-size: 18px;
@@ -28,7 +28,7 @@ export const Card = styled.div`
       margin-bottom: 12px;
     }
 
-    h1 {
+    .title {
       font-size: 24px;
       font-weight: 700;
       line-height: 1;

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -204,7 +204,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
               visible={visibleMapgakcos}
               onClick={handleVisibleMapgakcos}
             >
-              모각코
+              맵각코
             </FilterButton>
             <Button
               style={registerButtonStyle}

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -25,6 +25,7 @@ import {
   getUserMarkerOverlays,
 } from "../../utils/map/overlay";
 import MapgakcoMarker from "./MapgakcoMarker";
+import UserMarker from "./UserMarker";
 
 interface Props {
   initialCenter: Position;
@@ -246,21 +247,13 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
         {visibleUsers &&
           userMarkerOverlays.map(
             ({ position, imageUrl, options: { text } }, index) => (
-              <CustomOverlayMap
+              <UserMarker
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
-                position={{ lat: position.lat, lng: position.lng }}
-                yAnchor={1}
-              >
-                <div className="marker--blue">
-                  <img
-                    className="marker__image"
-                    src={imageUrl}
-                    alt="유저 이미지"
-                  />
-                  <span className="marker__text">{text}</span>
-                </div>
-              </CustomOverlayMap>
+                position={position}
+                imageUrl={imageUrl}
+                text={text}
+              />
             )
           )}
 

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -43,10 +43,8 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
 
   const [visibleUsers, setVisibleUsers] = useState(false);
   const [visibleMapgakcos, setVisibleMapgakcos] = useState(false);
-
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
-
-  const [isMapClick, setIsMapClick] = useState(false);
+  const [isMarkerSelected, setIsMarkerSelected] = useState(false);
 
   const handleVisibleUsers = useCallback(() => {
     setVisibleUsers((prev) => !prev);
@@ -102,10 +100,11 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
 
     return { position, imageUrl, options };
   });
+
   const handleModalClose = useCallback(
     () => () => {
       setRegisterModalOpen(false);
-      setIsMapClick(false);
+      setIsMarkerSelected(false);
       initializeClick();
     },
     [initializeClick]
@@ -124,6 +123,14 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
     boxShadow: theme.boxShadows.primary,
   };
 
+  const registerButtonStyle = {
+    ...buttonStyle,
+    color: isMarkerSelected && theme.colors.white,
+    backgroundColor: isMarkerSelected
+      ? theme.colors.markerBlue
+      : theme.colors.white,
+  };
+
   const guideTextStyle = {
     background: theme.colors.white,
     padding: "8px",
@@ -132,18 +139,53 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
     color: "#91979a",
   };
 
+  const getMarkerPosition = () => {
+    if (userClickPosition.lat && userClickPosition.lng) {
+      return {
+        lat: userClickPosition.lat,
+        lng: userClickPosition.lng,
+      };
+    }
+
+    if (targetPlace.x && targetPlace.y) {
+      return {
+        lat: targetPlace.y,
+        lng: targetPlace.x,
+      };
+    }
+
+    return {
+      lat: initialCenter.lat,
+      lng: initialCenter.lng,
+    };
+  };
+
   useEffect(() => {
     if (userClickPosition.lat && userClickPosition.lng) {
-      setIsMapClick(true);
+      setIsMarkerSelected(true);
+      setTargetPlace({ y: null, x: null });
     }
-  }, [userClickPosition]);
+
+    if (targetPlace.y && targetPlace.x) {
+      setIsMarkerSelected(true);
+      initializeClick();
+    }
+
+    // eslint-react-hooks가 권장하는대로 targetPlace를 넣을 경우 무한 리렌더링이 발생하므로 넣지 않고 린트 규칙을 비활성화한다
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    targetPlace.x,
+    targetPlace.y,
+    userClickPosition.lat,
+    userClickPosition.lng,
+  ]);
 
   return (
     <Container>
       <MapFloatContainer>
         <Modal visible={isRegisterModalOpen} width="60%">
           <MapgakcoRegister
-            userClickPosition={userClickPosition}
+            userClickPosition={getMarkerPosition()}
             onClose={handleModalClose()}
           />
         </Modal>
@@ -165,9 +207,9 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
               모각코
             </FilterButton>
             <Button
-              style={buttonStyle}
+              style={registerButtonStyle}
               onClick={handleRegisterClick}
-              disabled={!isMapClick}
+              disabled={!isMarkerSelected}
             >
               등록
             </Button>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -100,6 +100,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   const handleModalClose = useCallback(
     () => () => {
       setRegisterModalOpen(false);
+      setDetailModalOpen(false);
       setIsMarkerSelected(false);
       initializeClick();
     },
@@ -199,7 +200,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             height: "100%",
           }}
         >
-          <MapgakcoDetail />
+          <MapgakcoDetail onClose={handleModalClose()} />
         </Modal>
         <SearchContainer>
           <PlaceSearchFormWrapper>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -21,6 +21,10 @@ import {
   SearchContainer,
 } from "./styles";
 import { ImageMarkerOverlay, Mapgakco } from "../../types/mapTypes";
+import {
+  getMapgakcoMarkerOverlays,
+  getUserMarkerOverlays,
+} from "../../utils/map/overlay";
 
 interface Props {
   initialCenter: Position;
@@ -87,35 +91,8 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
     });
   }, []);
 
-  const userMarkerOverlays = userMapInfos.map((userMapInfo) => {
-    const position = {
-      lat: userMapInfo?.latitude,
-      lng: userMapInfo?.longitude,
-    };
-
-    const imageUrl = userMapInfo.profileImgUrl;
-
-    const options = {
-      color: "blue",
-      text: userMapInfo.name,
-    };
-
-    return { position, imageUrl, options };
-  });
-
-  const mapgakcoMarkerOverlays = (mapgakcos || []).map((mapgakco) => {
-    const position = {
-      lat: mapgakco?.latitude,
-      lng: mapgakco?.longitude,
-    };
-
-    const options = {
-      color: "green",
-      text: mapgakco.title,
-    };
-
-    return { position, options };
-  });
+  const userMarkerOverlays = getUserMarkerOverlays(userMapInfos);
+  const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
 
   const getMarkerOVerlays = (): ImageMarkerOverlay[] => {
     const markerOverlays = [];

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -49,11 +49,12 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
     x: null,
   });
 
-  const [visibleUsers, setVisibleUsers] = useState(false);
-  const [visibleMapgakcos, setVisibleMapgakcos] = useState(true);
-  const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
-  const [isDetailModalOpen, setDetailModalOpen] = useState(true);
-  const [isMarkerSelected, setIsMarkerSelected] = useState(false);
+  const [visibleUsers, setVisibleUsers] = useState<boolean>(false);
+  const [visibleMapgakcos, setVisibleMapgakcos] = useState<boolean>(true);
+  const [isRegisterModalOpen, setRegisterModalOpen] = useState<boolean>(false);
+  const [isDetailModalOpen, setDetailModalOpen] = useState<boolean>(false);
+  const [isMarkerSelected, setIsMarkerSelected] = useState<boolean>(false);
+  const [selectedMapgakco, setSelectedMapgakco] = useState(null);
 
   const handleVisibleUsers = useCallback(() => {
     setVisibleUsers((prev) => !prev);
@@ -97,18 +98,20 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   const userMarkerOverlays = getUserMarkerOverlays(userMapInfos);
   const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
 
-  const handleModalClose = useCallback(
-    () => () => {
-      setRegisterModalOpen(false);
-      setDetailModalOpen(false);
-      setIsMarkerSelected(false);
-      initializeClick();
-    },
-    [initializeClick]
-  );
+  const handleModalClose = useCallback(() => {
+    setRegisterModalOpen(false);
+    setDetailModalOpen(false);
+    setIsMarkerSelected(false);
+    initializeClick();
+  }, [initializeClick]);
 
   const handleRegisterClick = useCallback(() => {
     setRegisterModalOpen(true);
+  }, []);
+
+  const handleMapgakcoClick = useCallback((mapgakco: Mapgakco) => {
+    setDetailModalOpen(true);
+    setSelectedMapgakco(mapgakco);
   }, []);
 
   const buttonStyle = {
@@ -183,7 +186,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
         <Modal visible={isRegisterModalOpen} width="60%">
           <MapgakcoRegister
             userClickPosition={getMarkerPosition()}
-            onClose={handleModalClose()}
+            onClose={handleModalClose}
           />
         </Modal>
         <Modal
@@ -200,7 +203,10 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             height: "100%",
           }}
         >
-          <MapgakcoDetail onModalClose={handleModalClose()} />
+          <MapgakcoDetail
+            mapgakco={selectedMapgakco}
+            onModalClose={handleModalClose}
+          />
         </Modal>
         <SearchContainer>
           <PlaceSearchFormWrapper>
@@ -262,7 +268,6 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
           />
         ) : null}
 
-        {/* 데둥이 마커 */}
         {visibleUsers &&
           userMarkerOverlays.map(
             ({ position, imageUrl, options: { text } }, index) => (
@@ -278,9 +283,14 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
 
         {visibleMapgakcos &&
           mapgakcoMarkerOverlays.map(
-            ({ position, options: { text } }, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <MapgakcoMarker key={index} position={position} text={text} />
+            ({ position, options: { text }, mapgakco }, index) => (
+              <MapgakcoMarker
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                position={position}
+                text={text}
+                onClick={() => handleMapgakcoClick(mapgakco)}
+              />
             )
           )}
       </Map>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { BsArrowRightCircle } from "react-icons/bs";
-import { Map, CustomOverlayMap, MapMarker } from "react-kakao-maps-sdk";
+import { Map, MapMarker } from "react-kakao-maps-sdk";
 import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import theme from "../../assets/theme";
 import useMapClick from "../../hooks/useMapClick";
@@ -26,6 +26,7 @@ import {
 } from "../../utils/map/overlay";
 import MapgakcoMarker from "./MapgakcoMarker";
 import UserMarker from "./UserMarker";
+import MapgakcoDetail from "./MapgakcoDetail";
 
 interface Props {
   initialCenter: Position;
@@ -51,6 +52,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   const [visibleUsers, setVisibleUsers] = useState(false);
   const [visibleMapgakcos, setVisibleMapgakcos] = useState(true);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
+  const [isDetailModalOpen, setDetailModalOpen] = useState(true);
   const [isMarkerSelected, setIsMarkerSelected] = useState(false);
 
   const handleVisibleUsers = useCallback(() => {
@@ -182,6 +184,22 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             userClickPosition={getMarkerPosition()}
             onClose={handleModalClose()}
           />
+        </Modal>
+        <Modal
+          visible={isDetailModalOpen}
+          width="320px"
+          height="100%"
+          modalContainerStyles={{
+            top: 0,
+            left: 0,
+            transform: "none",
+            borderRadius: 0,
+          }}
+          contentContainerStyles={{
+            height: "100%",
+          }}
+        >
+          <MapgakcoDetail />
         </Modal>
         <SearchContainer>
           <PlaceSearchFormWrapper>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -48,7 +48,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   });
 
   const [visibleUsers, setVisibleUsers] = useState(false);
-  const [visibleMapgakcos, setVisibleMapgakcos] = useState(false);
+  const [visibleMapgakcos, setVisibleMapgakcos] = useState(true);
   const [isRegisterModalOpen, setRegisterModalOpen] = useState(false);
   const [isMarkerSelected, setIsMarkerSelected] = useState(false);
 
@@ -232,9 +232,8 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
         center={{ lat: center.lat, lng: center.lng }}
         isPanto
         hasControl={false}
-        // imageMarkerOverlays={getMarkerOVerlays()}
-        removeImageMarkerOverlays={!visibleUsers}
-        mapgakcos={mapgakcos}
+        imageMarkerOverlays={getMarkerOVerlays()}
+        mapgakcos={[]}
         onClick={click}
       >
         {userClickPosition.lat && userClickPosition.lng ? (

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -200,7 +200,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             height: "100%",
           }}
         >
-          <MapgakcoDetail onClose={handleModalClose()} />
+          <MapgakcoDetail onModalClose={handleModalClose()} />
         </Modal>
         <SearchContainer>
           <PlaceSearchFormWrapper>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { BsArrowRightCircle } from "react-icons/bs";
-import { MapMarker } from "react-kakao-maps-sdk";
+import { Map, CustomOverlayMap, MapMarker } from "react-kakao-maps-sdk";
 import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import theme from "../../assets/theme";
 import useMapClick from "../../hooks/useMapClick";
@@ -8,7 +8,6 @@ import { Position } from "../../types/commonTypes";
 import Button from "../base/Button";
 import Modal from "../base/Modal";
 import Text from "../base/Text";
-import Mapbox from "../Mapbox/Mapbox";
 import FilterButton from "./FilterButton";
 import MapgakcoRegister from "../MapgakcoRegister";
 import PlaceSearchForm from "./PlaceSearchForm";
@@ -20,11 +19,12 @@ import {
   PlaceSearchFormWrapper,
   SearchContainer,
 } from "./styles";
-import { ImageMarkerOverlay, Mapgakco } from "../../types/mapTypes";
+import { Mapgakco } from "../../types/mapTypes";
 import {
   getMapgakcoMarkerOverlays,
   getUserMarkerOverlays,
 } from "../../utils/map/overlay";
+import MapgakcoMarker from "./MapgakcoMarker";
 
 interface Props {
   initialCenter: Position;
@@ -93,20 +93,6 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
 
   const userMarkerOverlays = getUserMarkerOverlays(userMapInfos);
   const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
-
-  const getMarkerOVerlays = (): ImageMarkerOverlay[] => {
-    const markerOverlays = [];
-
-    if (visibleUsers) {
-      markerOverlays.push(...userMarkerOverlays);
-    }
-
-    if (visibleMapgakcos) {
-      markerOverlays.push(...mapgakcoMarkerOverlays);
-    }
-
-    return markerOverlays;
-  };
 
   const handleModalClose = useCallback(
     () => () => {
@@ -228,12 +214,16 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
           </Text>
         </Guide>
       </MapFloatContainer>
-      <Mapbox
-        center={{ lat: center.lat, lng: center.lng }}
-        isPanto
-        hasControl={false}
-        imageMarkerOverlays={getMarkerOVerlays()}
-        mapgakcos={[]}
+      <Map
+        center={{
+          lat: center.lat,
+          lng: center.lng,
+        }}
+        style={{
+          width: "100%",
+          height: "100%",
+        }}
+        level={4}
         onClick={click}
       >
         {userClickPosition.lat && userClickPosition.lng ? (
@@ -251,7 +241,37 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             }}
           />
         ) : null}
-      </Mapbox>
+
+        {/* 데둥이 마커 */}
+        {visibleUsers &&
+          userMarkerOverlays.map(
+            ({ position, imageUrl, options: { text } }, index) => (
+              <CustomOverlayMap
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                position={{ lat: position.lat, lng: position.lng }}
+                yAnchor={1}
+              >
+                <div className="marker--blue">
+                  <img
+                    className="marker__image"
+                    src={imageUrl}
+                    alt="유저 이미지"
+                  />
+                  <span className="marker__text">{text}</span>
+                </div>
+              </CustomOverlayMap>
+            )
+          )}
+
+        {visibleMapgakcos &&
+          mapgakcoMarkerOverlays.map(
+            ({ position, options: { text } }, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <MapgakcoMarker key={index} position={position} text={text} />
+            )
+          )}
+      </Map>
     </Container>
   );
 };

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -203,10 +203,12 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
             height: "100%",
           }}
         >
-          <MapgakcoDetail
-            mapgakco={selectedMapgakco}
-            onModalClose={handleModalClose}
-          />
+          {selectedMapgakco && (
+            <MapgakcoDetail
+              mapgakco={selectedMapgakco}
+              onModalClose={handleModalClose}
+            />
+          )}
         </Modal>
         <SearchContainer>
           <PlaceSearchFormWrapper>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -98,16 +98,16 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   const userMarkerOverlays = getUserMarkerOverlays(userMapInfos);
   const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
 
-  const handleModalClose = useCallback(() => {
+  const handleRegisterModalClose = useCallback(() => {
     setRegisterModalOpen(false);
-    setDetailModalOpen(false);
     setIsMarkerSelected(false);
     initializeClick();
   }, [initializeClick]);
 
-  const handleRegisterClick = useCallback(() => {
-    setRegisterModalOpen(true);
-  }, []);
+  const handleDetailModalClose = () => setDetailModalOpen(false);
+
+  // TODO: 알아보기. useCallback하면 DetailModal이 닫히고 나서 정상적으로 동작하지 않는다.
+  const handleRegisterClick = () => setRegisterModalOpen(true);
 
   const handleMapgakcoClick = useCallback((mapgakco: Mapgakco) => {
     setDetailModalOpen(true);
@@ -186,7 +186,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
         <Modal visible={isRegisterModalOpen} width="60%">
           <MapgakcoRegister
             userClickPosition={getMarkerPosition()}
-            onClose={handleModalClose}
+            onClose={handleRegisterModalClose}
           />
         </Modal>
         <Modal
@@ -206,7 +206,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
           {selectedMapgakco && (
             <MapgakcoDetail
               mapgakco={selectedMapgakco}
-              onModalClose={handleModalClose}
+              onModalClose={handleDetailModalClose}
             />
           )}
         </Modal>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -232,8 +232,9 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
         center={{ lat: center.lat, lng: center.lng }}
         isPanto
         hasControl={false}
-        imageMarkerOverlays={getMarkerOVerlays()}
+        // imageMarkerOverlays={getMarkerOVerlays()}
         removeImageMarkerOverlays={!visibleUsers}
+        mapgakcos={mapgakcos}
         onClick={click}
       >
         {userClickPosition.lat && userClickPosition.lng ? (

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -20,13 +20,15 @@ import {
   PlaceSearchFormWrapper,
   SearchContainer,
 } from "./styles";
+import { ImageMarkerOverlay, Mapgakco } from "../../types/mapTypes";
 
 interface Props {
   initialCenter: Position;
   userMapInfos: UserMapInfo[];
+  mapgakcos: Mapgakco[];
 }
 
-const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
+const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
   const memoCenter = useRef(initialCenter);
 
   const [userClickPosition, click, initializeClick] = useMapClick();
@@ -85,7 +87,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
     });
   }, []);
 
-  const imageMarkerOverlays = userMapInfos.map((userMapInfo) => {
+  const userMarkerOverlays = userMapInfos.map((userMapInfo) => {
     const position = {
       lat: userMapInfo?.latitude,
       lng: userMapInfo?.longitude,
@@ -100,6 +102,34 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
 
     return { position, imageUrl, options };
   });
+
+  const mapgakcoMarkerOverlays = (mapgakcos || []).map((mapgakco) => {
+    const position = {
+      lat: mapgakco?.latitude,
+      lng: mapgakco?.longitude,
+    };
+
+    const options = {
+      color: "green",
+      text: mapgakco.title,
+    };
+
+    return { position, options };
+  });
+
+  const getMarkerOVerlays = (): ImageMarkerOverlay[] => {
+    const markerOverlays = [];
+
+    if (visibleUsers) {
+      markerOverlays.push(...userMarkerOverlays);
+    }
+
+    if (visibleMapgakcos) {
+      markerOverlays.push(...mapgakcoMarkerOverlays);
+    }
+
+    return markerOverlays;
+  };
 
   const handleModalClose = useCallback(
     () => () => {
@@ -225,7 +255,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos }: Props) => {
         center={{ lat: center.lat, lng: center.lng }}
         isPanto
         hasControl={false}
-        imageMarkerOverlays={visibleUsers ? imageMarkerOverlays : []}
+        imageMarkerOverlays={getMarkerOVerlays()}
         removeImageMarkerOverlays={!visibleUsers}
         onClick={click}
       >

--- a/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
@@ -1,11 +1,11 @@
 import { useRecoilValue } from "recoil";
 import randomUserMapInfo from "../../../fixtures/userMapInfo";
-import { currentUserState } from "../../atoms/user";
+import { globalMyProfile } from "../../atoms/user";
 import { common } from "../../constants";
 import MapgakcoMap from "./MapgakcoMap";
 
 const MapgakcoMapContainer = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValue(globalMyProfile);
 
   const userMapInfos = Array.from({ length: 120 }, () => randomUserMapInfo());
 

--- a/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
@@ -2,6 +2,7 @@ import { useRecoilValue } from "recoil";
 import randomUserMapInfo from "../../../fixtures/userMapInfo";
 import { globalMyProfile } from "../../atoms/user";
 import { common } from "../../constants";
+import useMapgakcos from "../../hooks/useMapgakcos";
 import MapgakcoMap from "./MapgakcoMap";
 
 const MapgakcoMapContainer = () => {
@@ -14,7 +15,15 @@ const MapgakcoMapContainer = () => {
     lng: currentUser?.introduction?.longitude || common.defaultPosition.lng,
   };
 
-  return <MapgakcoMap initialCenter={center} userMapInfos={userMapInfos} />;
+  const { data: mapgakcos } = useMapgakcos();
+
+  return (
+    <MapgakcoMap
+      initialCenter={center}
+      userMapInfos={userMapInfos}
+      mapgakcos={mapgakcos}
+    />
+  );
 };
 
 export default MapgakcoMapContainer;

--- a/src/components/MapgakcoMap/MapgakcoMarker.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMarker.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+
+import { useCallback } from "react";
+import { CustomOverlayMap, MapMarker } from "react-kakao-maps-sdk";
+import { Position } from "../../types/commonTypes";
+
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+interface Props {
+  position: Position;
+  text: string;
+}
+
+const MapgakcoMarker = ({ position, text }: Props) => {
+  const handleClick = useCallback(
+    () => (event: React.MouseEvent) => {
+      event.preventDefault();
+    },
+    []
+  );
+
+  return (
+    <>
+      <MapMarker position={{ lat: position.lat, lng: position.lng }} />
+      <CustomOverlayMap
+        clickable
+        position={{ lat: position.lat, lng: position.lng }}
+        yAnchor={0.0}
+      >
+        <div className="customoverlay" onClick={() => alert("test")}>
+          <a href="#" onClick={handleClick}>
+            <span className="title">{text}</span>
+          </a>
+        </div>
+      </CustomOverlayMap>
+    </>
+  );
+};
+
+export default MapgakcoMarker;

--- a/src/components/MapgakcoMap/MapgakcoMarker.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMarker.tsx
@@ -9,9 +9,10 @@ import { Position } from "../../types/commonTypes";
 interface Props {
   position: Position;
   text: string;
+  onClick: () => void;
 }
 
-const MapgakcoMarker = ({ position, text }: Props) => {
+const MapgakcoMarker = ({ position, text, onClick }: Props) => {
   const handleClick = useCallback(
     () => (event: React.MouseEvent) => {
       event.preventDefault();
@@ -27,7 +28,7 @@ const MapgakcoMarker = ({ position, text }: Props) => {
         position={{ lat: position.lat, lng: position.lng }}
         yAnchor={0.0}
       >
-        <div className="customoverlay" onClick={() => alert("test")}>
+        <div className="customoverlay" onClick={onClick}>
           <a href="#" onClick={handleClick}>
             <span className="title">{text}</span>
           </a>

--- a/src/components/MapgakcoMap/UserMarker.tsx
+++ b/src/components/MapgakcoMap/UserMarker.tsx
@@ -1,0 +1,24 @@
+import { CustomOverlayMap } from "react-kakao-maps-sdk";
+import { Position } from "../../types/commonTypes";
+
+interface Props {
+  position: Position;
+  imageUrl: string;
+  text: string;
+}
+
+const UserMarker = ({ position, imageUrl, text }: Props) => {
+  return (
+    <CustomOverlayMap
+      position={{ lat: position.lat, lng: position.lng }}
+      yAnchor={1}
+    >
+      <div className="marker--blue">
+        <img className="marker__image" src={imageUrl} alt="유저 이미지" />
+        <span className="marker__text">{text}</span>
+      </div>
+    </CustomOverlayMap>
+  );
+};
+
+export default UserMarker;

--- a/src/components/MapgakcoMap/UserMarker.tsx
+++ b/src/components/MapgakcoMap/UserMarker.tsx
@@ -10,6 +10,7 @@ interface Props {
 const UserMarker = ({ position, imageUrl, text }: Props) => {
   return (
     <CustomOverlayMap
+      clickable
       position={{ lat: position.lat, lng: position.lng }}
       yAnchor={1}
     >

--- a/src/components/base/Modal/index.tsx
+++ b/src/components/base/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, ReactChild } from "react";
+import { useEffect, useMemo, ReactChild, CSSProperties } from "react";
 import ReactDOM from "react-dom";
 import Button from "../Button";
 import {
@@ -13,6 +13,8 @@ export interface Props {
   width?: number | string;
   height?: number | string;
   visible?: boolean;
+  modalContainerStyles?: CSSProperties;
+  contentContainerStyles?: CSSProperties;
   onClose?: () => void;
 }
 
@@ -21,13 +23,17 @@ const Modal = ({
   width = 500,
   height,
   visible = false,
+  modalContainerStyles = {},
+  contentContainerStyles = {},
   onClose,
 }: Props) => {
   const containerStyle = useMemo(
     () => ({
       width,
       height,
+      ...modalContainerStyles,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [width, height]
   );
 
@@ -42,7 +48,7 @@ const Modal = ({
   return ReactDOM.createPortal(
     <BackgroundDim visible={visible}>
       <ModalContainer style={{ ...containerStyle }}>
-        <ContentContainer>
+        <ContentContainer style={{ ...contentContainerStyles }}>
           <ButtonWrapper>
             {onClose && (
               <Button onClick={onClose} style={{ display: "none" }}>

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -1,0 +1,37 @@
+// TODO: 빠른 개발을 위해 리팩토링 기술 부채로 남겨둔다.
+/* eslint-disable no-restricted-syntax */
+import { useEffect, useRef } from "react";
+
+const events = ["mousedown", "touchstart"];
+
+const useClickAway = (handler) => {
+  const ref = useRef(null);
+  const savedHandler = useRef(handler);
+
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    const handleEvent = (e) => {
+      !element.contains(e.target) && savedHandler.current(e);
+    };
+
+    for (const eventName of events) {
+      document.addEventListener(eventName, handleEvent);
+    }
+
+    return () => {
+      for (const eventName of events) {
+        document.removeEventListener(eventName, handleEvent);
+      }
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+export default useClickAway;

--- a/src/hooks/useMapgakcos.ts
+++ b/src/hooks/useMapgakcos.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "react-query";
+import { requestGetMapgakcos } from "../utils/apis/mocks";
+
+const getMapgakcos = async () => {
+  const { data } = await requestGetMapgakcos();
+
+  return data?.data?.mapgakcos || [];
+};
+
+export default function useMapgakcos() {
+  return useQuery("mapgakcos", getMapgakcos);
+}

--- a/src/template/DefaultTemplate.tsx
+++ b/src/template/DefaultTemplate.tsx
@@ -7,6 +7,7 @@ import { topbarBgColorState } from "../atoms/topbarBgColor";
 import { topbarVisibleState } from "../atoms/topbarVisble";
 import SidebarContainer from "../components/Sidebar/SidebarContainer";
 import UserImageAndDropdownContainer from "../components/UserImageAndDropdown/UserImageAndDropdownContainer";
+import Text from "../components/base/Text";
 import { common, routes } from "../constants";
 import useMyProfile from "../hooks/useMyProfile";
 import { PageWrapper, Container, Header } from "./styles";
@@ -42,6 +43,9 @@ const DefaultTemplate = ({ children }: Props) => {
       <PageWrapper>
         {isShowTopbar && (
           <Header topbarBgColor={topbarBgColor}>
+            <Text strong size={15}>
+              {globalMyProfileData?.user?.name}
+            </Text>
             <UserImageAndDropdownContainer
               imageUrl={
                 globalMyProfileData?.introduction.profileImgUrl ||

--- a/src/template/styles.ts
+++ b/src/template/styles.ts
@@ -17,6 +17,7 @@ export const Header = styled.header<{ topbarBgColor }>`
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  gap: 4px;
   padding: 12px;
   background-color: ${({ topbarBgColor }) => topbarBgColor};
 `;

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -1,3 +1,4 @@
+import { CourseKeyType, RoleKeyType } from "../constants";
 import { ImageMarkerOverlayOptions } from "../utils/map/overlay";
 
 export interface Position {
@@ -16,6 +17,28 @@ export interface ImageMarker {
 
 export interface ImageMarkerOverlay {
   position: Position;
-  imageUrl: string;
+  imageUrl?: string;
   options?: ImageMarkerOverlayOptions;
+}
+
+export interface Author {
+  userId: number;
+  name: string;
+  course: CourseKeyType;
+  generation: number;
+  profileImgUrl: string | null;
+  role: RoleKeyType;
+}
+export interface Mapgakco {
+  mapgakcoId: number;
+  status: "GATHERING" | "CLOSED" | "FULL" | "DELETED";
+  title: string;
+  location: string;
+  meetingAt: string;
+  latitude: number;
+  longitude: number;
+  applicantLimit: number;
+  applicantCount: number;
+  createdAt: string;
+  author: Author;
 }

--- a/src/utils/apis/index.ts
+++ b/src/utils/apis/index.ts
@@ -5,3 +5,4 @@ export { requestMedia } from "./markdown";
 export { requestGetUserSuggestions, requestGetGatherSuggestions } from "./main";
 export { requestKeywordSearch } from "./search";
 export { requestPostCreateGather } from "./gather";
+export { requestMapgakcoRegister, requestGetMapgakcos } from "./mapgakco";

--- a/src/utils/apis/mapgakco.ts
+++ b/src/utils/apis/mapgakco.ts
@@ -3,3 +3,27 @@ import necessaryAuthAxiosInstance from "./necessaryAuthAxiosInstance";
 export const requestMapgakcoRegister = (values) => {
   return necessaryAuthAxiosInstance.post("v1/mapgakcos", values);
 };
+
+export const requestGetMapgakcos = (values) => {
+  const {
+    lastDistance,
+    centerX,
+    centerY,
+    currentNEX,
+    currentNEY,
+    currentSWX,
+    currentSWY,
+  } = values;
+
+  return necessaryAuthAxiosInstance.get("v1/mapgakcos", {
+    params: {
+      lastDistance: 0.0,
+      centerX: 37.566653033875774,
+      centerY: 126.97876549797886,
+      currentNEX: 37.57736394041695,
+      currentNEY: 127.03009029300624,
+      currentSWX: 37.55659510685803,
+      currentSWY: 126.9430729297755,
+    },
+  });
+};

--- a/src/utils/apis/mapgakco.ts
+++ b/src/utils/apis/mapgakco.ts
@@ -4,16 +4,17 @@ export const requestMapgakcoRegister = (values) => {
   return necessaryAuthAxiosInstance.post("v1/mapgakcos", values);
 };
 
-export const requestGetMapgakcos = (values) => {
-  const {
-    lastDistance,
-    centerX,
-    centerY,
-    currentNEX,
-    currentNEY,
-    currentSWX,
-    currentSWY,
-  } = values;
+export const requestGetMapgakcos = () => {
+  // TODO: API 명세에서는 get 요청으로 body를 보내야 하는데 axios.get에는 body를 보낼 수 없다. 이 문제가 해결되지 않아 일단 주석처리한다.
+  // const {
+  //   lastDistance,
+  //   centerX,
+  //   centerY,
+  //   currentNEX,
+  //   currentNEY,
+  //   currentSWX,
+  //   currentSWY,
+  // } = values;
 
   return necessaryAuthAxiosInstance.get("v1/mapgakcos", {
     params: {

--- a/src/utils/apis/mocks/index.ts
+++ b/src/utils/apis/mocks/index.ts
@@ -1,1 +1,2 @@
 export { requestGetUserSuggestions, requestGetGatherSuggestions } from "./main";
+export { requestGetMapgakcos } from "./mapgakcos";

--- a/src/utils/apis/mocks/mapgakcos.ts
+++ b/src/utils/apis/mocks/mapgakcos.ts
@@ -1,0 +1,9 @@
+import unnecessaryAuthAxiosInstance from "../unnecessaryAuthAxiosInstance";
+
+const url = {
+  GET_MAPGAKCOS: "https://run.mocky.io/v3/d5dc0739-764a-481b-9f3e-c92e2f6d8618",
+};
+
+export const requestGetMapgakcos = () => {
+  return unnecessaryAuthAxiosInstance.get(url.GET_MAPGAKCOS);
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,8 @@
+export const koreanDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hour = date.getHours();
+
+  return `${year}-${month}-${day} ${hour}시`;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,8 +1,15 @@
+const ampmHours = (hours: number) => {
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const hoursIn12Hour = hours % 12 || 12;
+
+  return `${hoursIn12Hour}${ampm}`;
+};
+
 export const koreanDate = (date: Date) => {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
-  const hour = date.getHours();
+  const hour = ampmHours(date.getHours());
 
-  return `${year}-${month}-${day} ${hour}시`;
+  return `${year}년 ${month}월 ${day}일 ${hour}`;
 };

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -1,4 +1,5 @@
-import { Position } from "../../types/mapTypes";
+import { UserMapInfo } from "../../../fixtures/userMapInfo";
+import { Mapgakco, Position } from "../../types/mapTypes";
 
 interface CustomOverlayProps {
   map: kakao.maps.Map;
@@ -82,4 +83,39 @@ export const addImageMarkerOverlay = ({
 
 export const removeOverlay = (customOverlay: kakao.maps.CustomOverlay) => {
   customOverlay.setMap(null);
+};
+
+// TODO: 리팩터링. getUserMarkerOverlays와 getMapgakcoMarkerOverlays를 하나의 함수로 처리한다.
+export const getUserMarkerOverlays = (userMapInfos: UserMapInfo[]) => {
+  return userMapInfos.map((userMapInfo) => {
+    const position = {
+      lat: userMapInfo?.latitude,
+      lng: userMapInfo?.longitude,
+    };
+
+    const imageUrl = userMapInfo.profileImgUrl;
+
+    const options = {
+      color: "blue",
+      text: userMapInfo.name,
+    };
+
+    return { position, imageUrl, options };
+  });
+};
+
+export const getMapgakcoMarkerOverlays = (mapgakcos: Mapgakco[]) => {
+  return (mapgakcos || []).map((mapgakco) => {
+    const position = {
+      lat: mapgakco?.latitude,
+      lng: mapgakco?.longitude,
+    };
+
+    const options = {
+      color: "green",
+      text: mapgakco.title,
+    };
+
+    return { position, options };
+  });
 };

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -1,5 +1,6 @@
 import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import { Mapgakco, Position } from "../../types/mapTypes";
+import { koreanDate } from "../date";
 
 interface CustomOverlayProps {
   map: kakao.maps.Map;
@@ -83,6 +84,84 @@ export const addImageMarkerOverlay = ({
 
 export const removeOverlay = (customOverlay: kakao.maps.CustomOverlay) => {
   customOverlay.setMap(null);
+};
+
+interface MapgakcoOverlayProps {
+  map: kakao.maps.Map;
+  mapgakco: Mapgakco;
+}
+
+export const addMapgakcoOverlay = ({ map, mapgakco }: MapgakcoOverlayProps) => {
+  const {
+    mapgakcoId,
+    status,
+    title,
+    location,
+    meetingAt,
+    latitude,
+    longitude,
+    applicantLimit,
+    applicantCount,
+    // author,
+  } = mapgakco;
+
+  // const { name, profileImageUrl } = author;
+
+  const $mapgakco = document.createElement("div");
+  const $header = document.createElement("header");
+  const $status = document.createElement("span");
+  const $section = document.createElement("section");
+  const $title = document.createElement("a");
+  const $list = document.createElement("ul");
+  const $row1 = document.createElement("li");
+  const $rowItem1 = document.createElement("div");
+  const $row2 = document.createElement("li");
+  const $rowItem2 = document.createElement("li");
+  const $row3 = document.createElement("li");
+  const $rowItem3 = document.createElement("div");
+
+  $mapgakco.classList.add("mapgakco");
+  $header.classList.add("mapgakco__header");
+  $status.classList.add("mapgakco__status");
+  $section.classList.add("mapgakco__section");
+  $title.classList.add("mapgakco__title");
+  $list.classList.add("mapgakco__list");
+  $row1.classList.add("mapgakco__row");
+  $rowItem1.classList.add("mapgakco__row-item");
+  $row2.classList.add("mapgakco__row");
+  $rowItem2.classList.add("mapgakco__row-item");
+  $row3.classList.add("mapgakco__row");
+  $rowItem3.classList.add("mapgakco__row-item");
+
+  $status.textContent = status;
+  $title.textContent = title;
+  $title.href = `/mapgakcos/${mapgakcoId}`;
+
+  $rowItem1.textContent = koreanDate(new Date(meetingAt));
+  $rowItem2.textContent = `${applicantCount} / ${applicantLimit} 명`;
+  $rowItem3.textContent = location;
+
+  $mapgakco.appendChild($header);
+  $header.appendChild($status);
+  $mapgakco.appendChild($section);
+  $section.appendChild($title);
+  $section.appendChild($list);
+  $list.appendChild($row1);
+  $row1.appendChild($rowItem1);
+  $list.appendChild($row2);
+  $row2.appendChild($rowItem2);
+  $list.appendChild($row3);
+  $row3.appendChild($rowItem3);
+
+  const customOverlay = addCustomOverlay({
+    map,
+    position: { lat: latitude, lng: longitude },
+    content: $mapgakco,
+  });
+
+  customOverlay.setMap(map);
+
+  return customOverlay;
 };
 
 // TODO: 리팩터링. getUserMarkerOverlays와 getMapgakcoMarkerOverlays를 하나의 함수로 처리한다.

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -195,6 +195,6 @@ export const getMapgakcoMarkerOverlays = (mapgakcos: Mapgakco[]) => {
       text: mapgakco.title,
     };
 
-    return { position, options };
+    return { position, options, mapgakco };
   });
 };


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

맵각코 페이지에서 맵각코 조회 기능을 추가한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #115 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 맵각코 상세 조회 모달 추가
- [x] 맵각코 지도 컴포넌트 설계 변경 (자체적으로 커스텀한 `Mapbox`에서 `react-kakao-maps-sdk` 패키지의 `Map`으로 전체 변경)
- [x] 맵각코 최초 조회 모킹 API 연동

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

https://user-images.githubusercontent.com/8105528/146674929-78530c9d-4553-459d-a77c-197abffa77f1.mov

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 아직 작업이 끝나지 않았는데 PR 범위가 커져서 올립니다. 그러다 보니 주석이 있거나 정제되지 않은 코드들이 있는데 머지되면 이어서 작업하겠습니다.
