### PR TITLE
DVT-#146 react-query 에러 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,14 @@
 import { ThemeProvider } from "@emotion/react";
-import { QueryClientProvider, QueryClient } from "react-query";
+import { QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { RecoilRoot } from "recoil";
 import Router from "./routes/Router";
 import DefaultTemplate from "./template/DefaultTemplate";
 import theme from "./assets/theme";
+import useCustomQueryClient from "./hooks/useCustomQueryClient";
 
 const App = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
+  const [queryClient] = useCustomQueryClient();
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -6,7 +6,7 @@ import { FormValues } from "./types";
 import { requestLogin } from "../../utils/apis";
 import { loginValidator } from "../../utils/yups/login";
 import { MutationData, MutationError } from "../../types/commonTypes";
-import { login, errorCode } from "../../constants";
+import { login } from "../../constants";
 import Login from "./Login";
 import { useLocalStorage } from "../../hooks";
 import { authState } from "../../atoms/auth";
@@ -22,18 +22,6 @@ const LoginContainer = () => {
         setToken(data.data.token);
         setAuthState(data.data.token);
         history.push("/");
-      },
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : login.message.UNKNOWN_ERROR;
-
-        if (response.status === errorCode.UNAUTHORIZED) {
-          setToken("");
-        }
-        // TODO: 에러가 발생할 경우 Toast를 띄워 사용자에게 알려준다. Toast가 완성될 경우 alert는 지운다.
-        // eslint-disable-next-line no-alert
-        alert(errorMessage);
       },
     }
   );

--- a/src/components/Signup/SignupContainer.tsx
+++ b/src/components/Signup/SignupContainer.tsx
@@ -7,26 +7,19 @@ import { requestSignup } from "../../utils/apis";
 import { signupValidator } from "../../utils/yups/signup";
 import { routes, signup } from "../../constants";
 import Signup from "./Signup";
+import useCustomToast from "../../hooks/useCustomToast";
 
 const SignupContainer = () => {
   const history = useHistory();
+
+  const [toast] = useCustomToast();
+
   const { mutate } = useMutation<MutationData, MutationError, unknown, unknown>(
     (values: FormValues) => requestSignup(values),
     {
       onSuccess: () => {
-        // TODO: 성공했을 경우 '회원가입이 완료되었습니다.' 문구를 Toast로 띄워 사용자에게 알려준다. Toast가 완성될 경우 alert는 지운다.
-        // eslint-disable-next-line no-alert
-        alert(signup.message.COMPLETED_SIGNUP);
+        toast({ message: signup.message.COMPLETED_SIGNUP });
         history.push(routes.LOGIN);
-      },
-      // https://github.com/tannerlinsley/react-query/discussions/1385
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : signup.message.UNKNOWN_ERROR;
-        // TODO: 에러가 발생할 경우 Toast를 띄워 사용자에게 알려준다. Toast가 완성될 경우 alert는 지운다.
-        // eslint-disable-next-line no-alert
-        alert(errorMessage);
       },
     }
   );

--- a/src/components/UserList/UserListContainer.tsx
+++ b/src/components/UserList/UserListContainer.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../../constants";
+import { useState } from "react";
+import { common } from "../../constants";
 import useUserInfiniteQuery from "../../hooks/useUserInfiniteQuery";
 import { Filters } from "./types";
 import UserList from "./UserList";
@@ -14,22 +13,13 @@ const UserListContainer = () => {
     nextLastId: null,
     size: common.userListInfinitePageCount,
   });
-  const history = useHistory();
 
-  // TODO: 로딩처리 해야 함
   const {
     data: pages,
     isLoading,
-    isError,
     hasNextPage,
     fetchNextPage,
   } = useUserInfiniteQuery(filters);
-
-  useEffect(() => {
-    if (isError) {
-      history.push(routes.LOGIN);
-    }
-  }, [isError, history]);
 
   return (
     <UserList

--- a/src/hooks/useCustomQueryClient.ts
+++ b/src/hooks/useCustomQueryClient.ts
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+import { MutationCache, QueryCache, QueryClient } from "react-query";
+import { useHistory } from "react-router-dom";
+import { useLocalStorage } from ".";
+import { common, errorCode, login, routes } from "../constants";
+import useCustomToast from "./useCustomToast";
+
+const useCustomQueryClient = () => {
+  const history = useHistory();
+
+  const [toast] = useCustomToast();
+
+  const [, setToken] = useLocalStorage(login.localStorageKey.TOKEN, "");
+
+  // query, mutation의 에러처리 로직이 달라져야 한다면 분리 필요
+  const onErrorHandler = useCallback(
+    ({ response }) => {
+      const errorMessage = response
+        ? response.data.message
+        : common.message.UNKNOWN_ERROR;
+
+      if (
+        response === undefined ||
+        response?.status === errorCode.UNAUTHORIZED ||
+        response?.status === errorCode.FORBIDDEN
+      ) {
+        setToken("");
+        history.push(routes.LOGIN);
+      } else if (response?.status === errorCode.NOT_FOUND) {
+        history.goBack();
+      }
+
+      toast({ message: errorMessage });
+    },
+    [history, setToken, toast]
+  );
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+
+    queryCache: new QueryCache({
+      onError: onErrorHandler,
+    }),
+
+    mutationCache: new MutationCache({
+      onError: onErrorHandler,
+    }),
+  });
+
+  return [queryClient];
+};
+
+export default useCustomQueryClient;

--- a/src/hooks/useIntroduction.ts
+++ b/src/hooks/useIntroduction.ts
@@ -1,23 +1,14 @@
 import { useQuery } from "react-query";
-import { common } from "../constants";
 import { requestGetIntroductions } from "../utils/apis/introductions";
 
-const useIntroduction = (introductionId) =>
-  useQuery(
+const useIntroduction = (introductionId) => {
+  return useQuery(
     ["introductions", introductionId],
     () => requestGetIntroductions(introductionId),
     {
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : common.message.UNKNOWN_ERROR;
-        // TODO: 에러가 발생할 경우 Toast를 띄워 사용자에게 알려준다.
-        // eslint-disable-next-line
-        alert(errorMessage);
-      },
-
       retry: false,
     }
   );
+};
 
 export default useIntroduction;

--- a/src/hooks/useMutationMapgakcoRegister.ts
+++ b/src/hooks/useMutationMapgakcoRegister.ts
@@ -1,12 +1,8 @@
 import { useMutation } from "react-query";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../constants";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestMapgakcoRegister } from "../utils/apis/mapgakco";
 
 const useMutationMapgakcoRegister = () => {
-  const history = useHistory();
-
   return useMutation<MutationData, MutationError, unknown, unknown>(
     "mapgakcoRegister",
     (values) => requestMapgakcoRegister(values),
@@ -14,19 +10,6 @@ const useMutationMapgakcoRegister = () => {
       onSuccess: () => {
         // TODO: 체오에게 물어볼 예정 (맵각코 지도 조회하는 queryId가 필요함)
         // queryClient.invalidateQueries("해당 쿼리 아이디");
-      },
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : common.message.EXPIRE_OR_SERVER_ERROR;
-
-        // TODO: 에러처리 토스트
-        // eslint-disable-next-line
-        alert(errorMessage);
-
-        if (!response) {
-          history.push(routes.LOGIN);
-        }
       },
     }
   );

--- a/src/hooks/useMutationUserDeleteLike.ts
+++ b/src/hooks/useMutationUserDeleteLike.ts
@@ -1,12 +1,9 @@
 import { useMutation, useQueryClient } from "react-query";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../constants";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestUserDeleteLike } from "../utils/apis/introductions";
 
 const useMutationUserDeleteLike = () => {
   const queryClient = useQueryClient();
-  const history = useHistory();
 
   return useMutation<MutationData, MutationError, unknown, unknown>(
     "userDeleteLike",
@@ -14,19 +11,6 @@ const useMutationUserDeleteLike = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries("introductions");
-      },
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : common.message.EXPIRE_OR_SERVER_ERROR;
-
-        // TODO: 에러처리 토스트
-        // eslint-disable-next-line
-        alert(errorMessage);
-
-        if (!response) {
-          history.push(routes.LOGIN);
-        }
       },
     }
   );

--- a/src/hooks/useMutationUserLike.ts
+++ b/src/hooks/useMutationUserLike.ts
@@ -1,12 +1,9 @@
 import { useMutation, useQueryClient } from "react-query";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../constants";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestUserLike } from "../utils/apis/introductions";
 
 const useMutationUserLike = () => {
   const queryClient = useQueryClient();
-  const history = useHistory();
 
   return useMutation<MutationData, MutationError, unknown, unknown>(
     "userLike",
@@ -14,19 +11,6 @@ const useMutationUserLike = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries("introductions");
-      },
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : common.message.EXPIRE_OR_SERVER_ERROR;
-
-        // TODO: 에러처리 토스트
-        // eslint-disable-next-line
-        alert(errorMessage);
-
-        if (!response) {
-          history.push(routes.LOGIN);
-        }
       },
     }
   );

--- a/src/hooks/useMutationUserModifyComment.ts
+++ b/src/hooks/useMutationUserModifyComment.ts
@@ -1,6 +1,4 @@
 import { useMutation, useQueryClient } from "react-query";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../constants";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestUserModifyComment } from "../utils/apis/introductions";
 
@@ -12,7 +10,6 @@ interface Variables {
 
 const useMutationUserModifyComment = () => {
   const queryClient = useQueryClient();
-  const history = useHistory();
 
   return useMutation<MutationData, MutationError, Variables, unknown>(
     "userDetailWriteComment",
@@ -20,19 +17,6 @@ const useMutationUserModifyComment = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries("introductions");
-      },
-      onError: ({ response }) => {
-        const errorMessage = response
-          ? response.data.message
-          : common.message.UNKNOWN_ERROR;
-
-        // TODO: 에러처리 토스트
-        // eslint-disable-next-line
-        alert(errorMessage);
-
-        if (!response) {
-          history.push(routes.LOGIN);
-        }
       },
     }
   );

--- a/src/hooks/useQueryCheckValidLink.ts
+++ b/src/hooks/useQueryCheckValidLink.ts
@@ -1,24 +1,8 @@
 import { useQuery } from "react-query";
-import { useHistory } from "react-router-dom";
-import { common, routes } from "../constants";
 import { requestCheckValidLink } from "../utils/apis/admin";
-import useCustomToast from "./useCustomToast";
 
 const useQueryCheckValidLink = (linkUuid) => {
-  const history = useHistory();
-  const [toast] = useCustomToast();
-
   return useQuery("checkValidLink", () => requestCheckValidLink(linkUuid), {
-    onError: ({ response }) => {
-      const errorMessage = response
-        ? response.data.message
-        : common.message.EXPIRE_OR_SERVER_ERROR;
-
-      if (response) {
-        history.push(routes.LOGIN);
-        toast({ message: errorMessage });
-      }
-    },
     enabled: false,
     retry: false,
   });

--- a/src/hooks/useUserInfiniteQuery.ts
+++ b/src/hooks/useUserInfiniteQuery.ts
@@ -1,9 +1,9 @@
 import { useInfiniteQuery } from "react-query";
 import { requestGetFilteredUsers } from "../utils/apis/introductions";
 
-const useMutationUserDeleteComment = (filters) => {
+const useUserInfiniteQuery = (filters) => {
   return useInfiniteQuery(
-    ["filteredUsers2", filters],
+    ["filteredUsers", filters],
     ({ pageParam }) => requestGetFilteredUsers(filters, pageParam),
     {
       getNextPageParam: (lastPage) => {
@@ -15,8 +15,9 @@ const useMutationUserDeleteComment = (filters) => {
           : lastPage.data.data.nextLastId;
       },
       staleTime: 1000 * 10,
+      retry: false,
     }
   );
 };
 
-export default useMutationUserDeleteComment;
+export default useUserInfiniteQuery;


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

react-query `onError` 핸들러를 전역으로 관리한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #146 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] react-query의 useQuery, useMutation 에러 핸들러 공통으로 분리
- [x] 401, 403, 알 수 없는 오류일 경우 토큰을 지우고 로그인 화면으로 리다이렉트
- [x] 404 에러일 경우 history goBack
- [x] 500 에러일 경우 사용자 잘못이 아니기 때문에 라우팅 하지 않고 메세지만 띄워줌
- [x] 마이프로필 변경 후 globalMyProfile 쿼리 invalidate

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

없음

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

@datalater @ono212 
- react-query의 `useQuery`, `useMutation`의 `onError` 처리를 전역에서 하도록 했습니다. (src/hooks/useCustomQueryClient.ts) 그래서 기존에 사용하셨던 `onError` 부분을 지워주셔도 됩니다!!! 일단 제가 작업한 query, mutation만 진행했으니 각자 작업하신 부분은 꼭! 지워주세요 
