### PR TITLE
DVT-#154 레이아웃 피드백 반영

### DIFF
--- a/src/components/MapgakcoRegister/index.tsx
+++ b/src/components/MapgakcoRegister/index.tsx
@@ -21,6 +21,7 @@ import useMutationMapgakcoRegister from "../../hooks/useMutationMapgakcoRegister
 import { Position } from "../../types/commonTypes";
 import MarkdownEditor from "../base/MarkdownEditor";
 import useToastUi from "../../hooks/useToastUi";
+import Text from "../base/Text";
 
 interface IProps {
   userClickPosition: Position;
@@ -124,7 +125,9 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
     <Container>
       <FormContainer onSubmit={handleSubmit} autoComplete="off">
         <InputContainer>
-          <label htmlFor="applicantLimit">모집 인원</label>
+          <label htmlFor="applicantLimit">
+            <Text strong>모집 인원</Text>
+          </label>
           <Input
             type="number"
             name="applicantLimit"
@@ -140,7 +143,9 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
         </InputContainer>
 
         <InputContainer>
-          <label htmlFor="meetingAt">모임 날짜</label>
+          <label htmlFor="meetingAt">
+            <Text strong>모임 날짜</Text>
+          </label>
           <StyledDatePicker
             name="meetingAt"
             placeholderText="yyyy-mm-dd HH:mm"
@@ -160,7 +165,9 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
         </InputContainer>
 
         <InputContainer>
-          <label htmlFor="title">모임 제목</label>
+          <label htmlFor="title">
+            <Text strong>모임 제목</Text>
+          </label>
           <Input
             type="text"
             name="title"
@@ -174,7 +181,9 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
         </InputContainer>
 
         <InputContainer>
-          <label htmlFor="location">상세 장소</label>
+          <label htmlFor="location">
+            <Text strong>상세 장소</Text>
+          </label>
           <Input
             type="text"
             name="location"
@@ -188,7 +197,9 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
         </InputContainer>
 
         <InputContainer>
-          <label htmlFor="content">내용</label>
+          <label htmlFor="content">
+            <Text strong>내용</Text>
+          </label>
           <input
             type="hidden"
             name="content"

--- a/src/components/MapgakcoRegister/stlyes.ts
+++ b/src/components/MapgakcoRegister/stlyes.ts
@@ -14,6 +14,7 @@ export const ButtonContainer = styled.div`
   display: flex;
   gap: 0 20px;
   align-self: flex-end;
+  margin-top: auto;
 `;
 
 export const Button = styled.button`
@@ -48,6 +49,7 @@ export const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   gap: 16px 0;
+  height: 100%;
 `;
 
 export const ErrorMessage = styled.p`
@@ -76,7 +78,7 @@ export const StyledDatePicker = styled(DatePicker)`
 
 export const MarkdownEditorWrapper = styled.div`
   width: 100%;
-  height: 360px;
+  height: 400px;
   padding: 12px;
   border-radius: 10px;
   box-shadow: ${({ theme }) => theme.boxShadows.primary};

--- a/src/components/MapgakcoRegister/stlyes.ts
+++ b/src/components/MapgakcoRegister/stlyes.ts
@@ -6,6 +6,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   padding: 16px;
+  height: 90vh;
   overflow-y: auto;
 `;
 

--- a/src/components/MyProfile/MyProfile.tsx
+++ b/src/components/MyProfile/MyProfile.tsx
@@ -1,3 +1,4 @@
+import { HiPlusCircle } from "react-icons/hi";
 import { useCallback, useRef } from "react";
 import { MapMarker } from "react-kakao-maps-sdk";
 import { common, myProfile } from "../../constants";
@@ -14,9 +15,13 @@ import {
   MapWrapper,
   StyledMap,
   MarkdownEditorWrapper,
+  TitleWrapper,
+  ProfileModifyButton,
 } from "./styles";
 import { IProps } from "./types";
 import MarkdownEditor from "../base/MarkdownEditor";
+import Text from "../base/Text";
+import theme from "../../assets/theme";
 
 interface SelectOption {
   value: string | number;
@@ -68,11 +73,22 @@ const MyProfile = ({
 
   return (
     <Container>
-      <ProfileImage
-        src={formik.values.profileImgUrl || common.placeHolderImageSrc}
-        alt="profile"
-        onClick={handleImageClick}
-      />
+      <TitleWrapper>
+        <Text size={32} color={theme.colors.gray800} strong>
+          내 프로필
+        </Text>
+      </TitleWrapper>
+
+      <RowContainer onClick={handleImageClick} cursor>
+        <ProfileImage
+          src={formik.values.profileImgUrl || common.placeHolderImageSrc}
+          alt="profile"
+        />
+        <ProfileModifyButton>
+          <HiPlusCircle size={36} color={theme.colors.primary} />
+        </ProfileModifyButton>
+      </RowContainer>
+
       <MyProfileForm onSubmit={formik.handleSubmit}>
         <HiddenInput
           ref={inputRef}

--- a/src/components/MyProfile/styles.ts
+++ b/src/components/MyProfile/styles.ts
@@ -11,10 +11,17 @@ export const Container = styled.div`
   overflow-y: auto;
 `;
 
+export const TitleWrapper = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  width: 60%;
+  gap: 16px 0;
+`;
+
 export const MyProfileForm = styled.form`
   display: inline-flex;
   flex-direction: column;
-  width: 50%;
+  width: 60%;
   gap: 16px 0;
 `;
 
@@ -91,10 +98,12 @@ export const Select = styled.select`
   }
 `;
 
-export const RowContainer = styled.div`
+export const RowContainer = styled.div<{ cursor?: boolean }>`
+  position: relative;
   display: flex;
   justify-content: space-between;
   gap: 0 16px;
+  cursor: ${({ cursor }) => cursor && "pointer"};
 `;
 
 export const ColumnContainer = styled.div`
@@ -125,6 +134,7 @@ export const Textarea = styled.textarea`
 
 export const MapWrapper = styled.div`
   width: 100%;
+  min-height: 560px;
   height: 560px;
   border-radius: 10px;
   box-shadow: ${({ theme }) => theme.boxShadows.primary};
@@ -137,8 +147,17 @@ export const StyledMap = styled(Map)`
 
 export const MarkdownEditorWrapper = styled.div`
   width: 100%;
-  height: 360px;
+  min-height: 560px;
+  height: 100%;
   padding: 12px;
   border-radius: 10px;
   box-shadow: ${({ theme }) => theme.boxShadows.primary};
+`;
+
+export const ProfileModifyButton = styled.div`
+  bottom: 20px;
+  right: 20px;
+  position: absolute;
+  background-color: white;
+  border-radius: 50%;
 `;

--- a/src/components/UserDetail/Comment/index.tsx
+++ b/src/components/UserDetail/Comment/index.tsx
@@ -1,10 +1,11 @@
-import { FaComments } from "react-icons/fa";
-import { BsFillKeyboardFill } from "react-icons/bs";
 import { MdDeleteSweep, MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 import { useRecoilValue } from "recoil";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
+import dayjs from "dayjs";
+import "dayjs/locale/ko";
+import relativeTime from "dayjs/plugin/relativeTime";
 import {
   Container,
   ButtonContainer,
@@ -35,7 +36,10 @@ interface IProps {
 }
 
 const Comment = ({ comment, isChild, introductionId }: IProps) => {
+  const [fromNow, setFromNow] = useState<string | null>(null);
+
   const myProfile = useRecoilValue(globalMyProfile);
+
   const [isModifyClick, toggleModify] = useToggle(false);
   const [isChildCommentClick, toggleChildComment] = useToggle(false);
 
@@ -115,6 +119,12 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
     [userDeleteCommentMutate, introductionId, comment]
   );
 
+  useEffect(() => {
+    dayjs.extend(relativeTime);
+    dayjs.locale("ko");
+    setFromNow(dayjs(comment.updatedAt).fromNow());
+  }, [comment]);
+
   return (
     <Container>
       <CommentContainer>
@@ -145,7 +155,6 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
               }기`}
             </Text>
           </TextContainer>
-
           {isModifyClick ? (
             <InputWrapperForm onSubmit={modifyCommentformik.handleSubmit}>
               <Input
@@ -158,8 +167,12 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
               />
             </InputWrapperForm>
           ) : (
-            comment.content
+            <Text>{comment.content}</Text>
           )}
+
+          <Text size={12} color={theme.colors.gray500}>
+            {fromNow}
+          </Text>
         </ContentContainer>
 
         <ButtonContainer>
@@ -167,14 +180,18 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
             <>
               {!isChild && (
                 <IconButton role="button" onClick={handleChildCommentClick}>
-                  <FaComments size={24} />
+                  <Text size={12} color={theme.colors.gray600}>
+                    답글
+                  </Text>
                 </IconButton>
               )}
 
-              {myProfile.user.userId === comment.writer.userId && (
+              {myProfile?.user.userId === comment.writer.userId && (
                 <>
                   <IconButton role="button" onClick={handleModifyClick}>
-                    <BsFillKeyboardFill size={24} />
+                    <Text size={12} color={theme.colors.gray600}>
+                      수정
+                    </Text>
                   </IconButton>
                   <IconButton
                     role="button"

--- a/src/components/UserDetail/Comment/styles.ts
+++ b/src/components/UserDetail/Comment/styles.ts
@@ -37,6 +37,7 @@ export const IconButton = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  min-width: 28px;
   cursor: pointer;
 `;
 

--- a/src/components/UserDetail/UserDetail.tsx
+++ b/src/components/UserDetail/UserDetail.tsx
@@ -29,6 +29,8 @@ import {
   ContentContainer,
   DescriptionBorderContainer,
   EmptyTextWrapper,
+  IconWrapper,
+  CommentBorderContainer,
 } from "./styles";
 import MarkdownEditor from "../base/MarkdownEditor";
 import Comment from "./Comment";
@@ -127,7 +129,9 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
             href={`mailto:${userInfo.user.email}`}
             target="_blank"
           >
-            <MdEmail size={24} />
+            <IconWrapper>
+              <MdEmail size={24} />
+            </IconWrapper>
 
             <Text size={16} strong>
               {userInfo.user.email}
@@ -142,9 +146,11 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
             href={userInfo.introduction.githubUrl}
             target="_blank"
           >
-            <BsGithub size={24} />
+            <IconWrapper>
+              <BsGithub size={24} />
+            </IconWrapper>
 
-            <Text size={16} strong>
+            <Text ellipsisLineClamp={1} size={16} strong>
               {userInfo.introduction.githubUrl ||
                 "아직 깃허브 주소를 입력하지 않았어요"}
             </Text>
@@ -160,9 +166,11 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
             href={userInfo.introduction.blogUrl}
             target="_blank"
           >
-            <GiNotebook size={24} />
+            <IconWrapper>
+              <GiNotebook size={24} />
+            </IconWrapper>
 
-            <Text size={16} strong>
+            <Text ellipsisLineClamp={1} size={16} strong>
               {userInfo.introduction.blogUrl ||
                 "아직 블로그 주소를 입력하지 않았어요"}
             </Text>
@@ -218,13 +226,35 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
           </StyledMap>
         </BorderContainer>
 
-        <BorderContainer height={560}>
+        <CommentBorderContainer height={560}>
           <Text size={20} strong>
             댓글
           </Text>
 
+          <FormContainer onSubmit={handleSubmit}>
+            <HiddenLabel htmlFor="content">내용</HiddenLabel>
+
+            <Input
+              type="text"
+              name="content"
+              placeholder={common.message.ENTER_COMMENT}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              value={values.content}
+              maxLength={common.validation.COMMENT_MAX_LENGTH}
+            />
+
+            <Button type="submit">
+              <Text size={12} color="white" strong ellipsisLineClamp={1}>
+                <HiOutlinePencilAlt size={20} />
+              </Text>
+            </Button>
+          </FormContainer>
+
           {userInfo.comments?.length === 0 && (
-            <CommentContainer>{`${userInfo.user.name}님에게 제일 먼저 댓글을 달아주세요!`}</CommentContainer>
+            <CommentContainer>
+              <EmptyTextWrapper>{`${userInfo.user.name}님에게 제일 먼저 댓글을 달아주세요!`}</EmptyTextWrapper>
+            </CommentContainer>
           )}
 
           <CommentContainer>
@@ -246,26 +276,7 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
               </React.Fragment>
             ))}
           </CommentContainer>
-          <FormContainer onSubmit={handleSubmit}>
-            <HiddenLabel htmlFor="content">내용</HiddenLabel>
-
-            <Input
-              type="text"
-              name="content"
-              placeholder={common.message.ENTER_COMMENT}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              value={values.content}
-              maxLength={common.validation.COMMENT_MAX_LENGTH}
-            />
-
-            <Button type="submit">
-              <Text size={12} color="white" strong ellipsisLineClamp={1}>
-                <HiOutlinePencilAlt size={20} />
-              </Text>
-            </Button>
-          </FormContainer>
-        </BorderContainer>
+        </CommentBorderContainer>
       </ContentContainer>
     </Container>
   );

--- a/src/components/UserDetail/UserDetail.tsx
+++ b/src/components/UserDetail/UserDetail.tsx
@@ -27,6 +27,7 @@ import {
   UserTag,
   HiddenLabel,
   IconWrapper,
+  ContentContainer,
 } from "./styles";
 import MarkdownEditor from "../base/MarkdownEditor";
 import Comment from "./Comment";
@@ -115,117 +116,121 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
         </Text>
       </TextWrapper>
 
-      <BorderContainer>
-        <ContactContainer>
-          <MdEmail size={24} />
-
-          <Text size={16}>{userInfo.user.email}</Text>
-
-          <BlankLink href={`mailto:${userInfo.user.email}`} target="_blank">
-            <AiFillCaretRight size={24} />
-          </BlankLink>
-        </ContactContainer>
-
-        {userInfo.introduction.githubUrl && (
+      <ContentContainer>
+        <BorderContainer>
           <ContactContainer>
-            <BsGithub size={24} />
+            <MdEmail size={24} />
 
-            <Text size={16}>{userInfo.introduction.githubUrl}</Text>
+            <Text size={16}>{userInfo.user.email}</Text>
 
-            <BlankLink href={userInfo.introduction.githubUrl} target="_blank">
+            <BlankLink href={`mailto:${userInfo.user.email}`} target="_blank">
               <AiFillCaretRight size={24} />
             </BlankLink>
           </ContactContainer>
-        )}
 
-        {userInfo.introduction.blogUrl && (
-          <ContactContainer>
-            <GiNotebook size={24} />
+          {userInfo.introduction.githubUrl && (
+            <ContactContainer>
+              <BsGithub size={24} />
 
-            <Text size={16}>{userInfo.introduction.blogUrl}</Text>
+              <Text size={16}>{userInfo.introduction.githubUrl}</Text>
 
-            <BlankLink href={userInfo.introduction.blogUrl} target="_blank">
-              <AiFillCaretRight size={24} />
-            </BlankLink>
-          </ContactContainer>
-        )}
-      </BorderContainer>
+              <BlankLink href={userInfo.introduction.githubUrl} target="_blank">
+                <AiFillCaretRight size={24} />
+              </BlankLink>
+            </ContactContainer>
+          )}
 
-      {userInfo.introduction.description && (
-        <BorderContainer height={480}>
-          <MarkdownEditor
-            editorRef={null}
-            isViewMode
-            value={userInfo.introduction.description}
-          />
+          {userInfo.introduction.blogUrl && (
+            <ContactContainer>
+              <GiNotebook size={24} />
+
+              <Text size={16}>{userInfo.introduction.blogUrl}</Text>
+
+              <BlankLink href={userInfo.introduction.blogUrl} target="_blank">
+                <AiFillCaretRight size={24} />
+              </BlankLink>
+            </ContactContainer>
+          )}
         </BorderContainer>
-      )}
 
-      <BorderContainer height={560}>
-        <StyledMap
-          center={{
-            lat: userInfo.introduction.latitude || common.defaultPosition.lat,
-            lng: userInfo.introduction.longitude || common.defaultPosition.lng,
-          }}
-        >
-          <MapMarker
-            position={{
+        {userInfo.introduction.description && (
+          <BorderContainer height={480}>
+            <MarkdownEditor
+              editorRef={null}
+              isViewMode
+              value={userInfo.introduction.description}
+            />
+          </BorderContainer>
+        )}
+
+        <BorderContainer height={560}>
+          <StyledMap
+            center={{
               lat: userInfo.introduction.latitude || common.defaultPosition.lat,
               lng:
                 userInfo.introduction.longitude || common.defaultPosition.lng,
             }}
-          />
-        </StyledMap>
-      </BorderContainer>
+          >
+            <MapMarker
+              position={{
+                lat:
+                  userInfo.introduction.latitude || common.defaultPosition.lat,
+                lng:
+                  userInfo.introduction.longitude || common.defaultPosition.lng,
+              }}
+            />
+          </StyledMap>
+        </BorderContainer>
 
-      <BorderContainer height={560}>
-        <IconWrapper>
-          <MdModeComment size={24} />
-        </IconWrapper>
+        <BorderContainer height={560}>
+          <IconWrapper>
+            <MdModeComment size={24} />
+          </IconWrapper>
 
-        {userInfo.comments?.length === 0 && (
-          <CommentContainer>{`${userInfo.user.name}님에게 제일 먼저 댓글을 달아주세요!`}</CommentContainer>
-        )}
+          {userInfo.comments?.length === 0 && (
+            <CommentContainer>{`${userInfo.user.name}님에게 제일 먼저 댓글을 달아주세요!`}</CommentContainer>
+          )}
 
-        <CommentContainer>
-          {userInfo.comments?.map((comment) => (
-            <React.Fragment key={comment.commentId}>
-              <Comment
-                comment={comment}
-                introductionId={userInfo.introduction.introductionId}
-                isChild={false}
-              />
-              {comment.children?.map((child) => (
+          <CommentContainer>
+            {userInfo.comments?.map((comment) => (
+              <React.Fragment key={comment.commentId}>
                 <Comment
-                  key={`child${child.commentId}`}
-                  comment={child}
+                  comment={comment}
                   introductionId={userInfo.introduction.introductionId}
-                  isChild
+                  isChild={false}
                 />
-              ))}
-            </React.Fragment>
-          ))}
-        </CommentContainer>
-        <FormContainer onSubmit={handleSubmit}>
-          <HiddenLabel htmlFor="content">내용</HiddenLabel>
+                {comment.children?.map((child) => (
+                  <Comment
+                    key={`child${child.commentId}`}
+                    comment={child}
+                    introductionId={userInfo.introduction.introductionId}
+                    isChild
+                  />
+                ))}
+              </React.Fragment>
+            ))}
+          </CommentContainer>
+          <FormContainer onSubmit={handleSubmit}>
+            <HiddenLabel htmlFor="content">내용</HiddenLabel>
 
-          <Input
-            type="text"
-            name="content"
-            placeholder={common.message.ENTER_COMMENT}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            value={values.content}
-            maxLength={common.validation.COMMENT_MAX_LENGTH}
-          />
+            <Input
+              type="text"
+              name="content"
+              placeholder={common.message.ENTER_COMMENT}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              value={values.content}
+              maxLength={common.validation.COMMENT_MAX_LENGTH}
+            />
 
-          <Button type="submit">
-            <Text size={12} color="white" strong ellipsisLineClamp={1}>
-              <HiOutlinePencilAlt size={20} />
-            </Text>
-          </Button>
-        </FormContainer>
-      </BorderContainer>
+            <Button type="submit">
+              <Text size={12} color="white" strong ellipsisLineClamp={1}>
+                <HiOutlinePencilAlt size={20} />
+              </Text>
+            </Button>
+          </FormContainer>
+        </BorderContainer>
+      </ContentContainer>
     </Container>
   );
 };

--- a/src/components/UserDetail/UserDetail.tsx
+++ b/src/components/UserDetail/UserDetail.tsx
@@ -2,7 +2,6 @@ import { MdEmail } from "react-icons/md";
 import { HiOutlinePencilAlt } from "react-icons/hi";
 import { BsGithub } from "react-icons/bs";
 import { GiNotebook } from "react-icons/gi";
-import { AiFillCaretRight } from "react-icons/ai";
 import { MapMarker } from "react-kakao-maps-sdk";
 import { useFormik } from "formik";
 import * as Yup from "yup";
@@ -13,7 +12,6 @@ import Input from "../base/Input";
 import Text from "../base/Text";
 import LikeButtonAndText from "../LikeButtonAndText/LikeButtonAndText";
 import {
-  BlankLink,
   BorderContainer,
   Button,
   CommentContainer,
@@ -31,6 +29,7 @@ import {
   EmptyTextWrapper,
   IconWrapper,
   CommentBorderContainer,
+  EllipsisWrapper,
 } from "./styles";
 import MarkdownEditor from "../base/MarkdownEditor";
 import Comment from "./Comment";
@@ -103,7 +102,7 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
       </UserTag>
 
       {userInfo.introduction.mbti && (
-        <MbtiTag fontSize={16} mbti="ISFJ">
+        <MbtiTag fontSize={16} mbti={userInfo.introduction.mbti}>
           {userInfo.introduction.mbti}
         </MbtiTag>
       )}
@@ -136,10 +135,6 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
             <Text size={16} strong>
               {userInfo.user.email}
             </Text>
-
-            <BlankLink>
-              <AiFillCaretRight size={24} />
-            </BlankLink>
           </ContactContainer>
 
           <ContactContainer
@@ -150,16 +145,12 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
               <BsGithub size={24} />
             </IconWrapper>
 
-            <Text ellipsisLineClamp={1} size={16} strong>
-              {userInfo.introduction.githubUrl ||
-                "아직 깃허브 주소를 입력하지 않았어요"}
-            </Text>
-
-            {userInfo.introduction.githubUrl && (
-              <BlankLink>
-                <AiFillCaretRight size={24} />
-              </BlankLink>
-            )}
+            <EllipsisWrapper>
+              <Text size={16} strong>
+                {userInfo.introduction.githubUrl ||
+                  "아직 깃허브 주소를 입력하지 않았어요"}
+              </Text>
+            </EllipsisWrapper>
           </ContactContainer>
 
           <ContactContainer
@@ -170,16 +161,12 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
               <GiNotebook size={24} />
             </IconWrapper>
 
-            <Text ellipsisLineClamp={1} size={16} strong>
-              {userInfo.introduction.blogUrl ||
-                "아직 블로그 주소를 입력하지 않았어요"}
-            </Text>
-
-            {userInfo.introduction.blogUrl && (
-              <BlankLink>
-                <AiFillCaretRight size={24} />
-              </BlankLink>
-            )}
+            <EllipsisWrapper>
+              <Text size={16} strong>
+                {userInfo.introduction.blogUrl ||
+                  "아직 블로그 주소를 입력하지 않았어요"}
+              </Text>
+            </EllipsisWrapper>
           </ContactContainer>
         </BorderContainer>
 

--- a/src/components/UserDetail/UserDetail.tsx
+++ b/src/components/UserDetail/UserDetail.tsx
@@ -1,4 +1,4 @@
-import { MdEmail, MdModeComment } from "react-icons/md";
+import { MdEmail } from "react-icons/md";
 import { HiOutlinePencilAlt } from "react-icons/hi";
 import { BsGithub } from "react-icons/bs";
 import { GiNotebook } from "react-icons/gi";
@@ -26,8 +26,9 @@ import {
   TextWrapper,
   UserTag,
   HiddenLabel,
-  IconWrapper,
   ContentContainer,
+  DescriptionBorderContainer,
+  EmptyTextWrapper,
 } from "./styles";
 import MarkdownEditor from "../base/MarkdownEditor";
 import Comment from "./Comment";
@@ -118,52 +119,87 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
 
       <ContentContainer>
         <BorderContainer>
-          <ContactContainer>
+          <Text size={20} strong>
+            연락처
+          </Text>
+
+          <ContactContainer
+            href={`mailto:${userInfo.user.email}`}
+            target="_blank"
+          >
             <MdEmail size={24} />
 
-            <Text size={16}>{userInfo.user.email}</Text>
+            <Text size={16} strong>
+              {userInfo.user.email}
+            </Text>
 
-            <BlankLink href={`mailto:${userInfo.user.email}`} target="_blank">
+            <BlankLink>
               <AiFillCaretRight size={24} />
             </BlankLink>
           </ContactContainer>
 
-          {userInfo.introduction.githubUrl && (
-            <ContactContainer>
-              <BsGithub size={24} />
+          <ContactContainer
+            href={userInfo.introduction.githubUrl}
+            target="_blank"
+          >
+            <BsGithub size={24} />
 
-              <Text size={16}>{userInfo.introduction.githubUrl}</Text>
+            <Text size={16} strong>
+              {userInfo.introduction.githubUrl ||
+                "아직 깃허브 주소를 입력하지 않았어요"}
+            </Text>
 
-              <BlankLink href={userInfo.introduction.githubUrl} target="_blank">
+            {userInfo.introduction.githubUrl && (
+              <BlankLink>
                 <AiFillCaretRight size={24} />
               </BlankLink>
-            </ContactContainer>
-          )}
+            )}
+          </ContactContainer>
 
-          {userInfo.introduction.blogUrl && (
-            <ContactContainer>
-              <GiNotebook size={24} />
+          <ContactContainer
+            href={userInfo.introduction.blogUrl}
+            target="_blank"
+          >
+            <GiNotebook size={24} />
 
-              <Text size={16}>{userInfo.introduction.blogUrl}</Text>
+            <Text size={16} strong>
+              {userInfo.introduction.blogUrl ||
+                "아직 블로그 주소를 입력하지 않았어요"}
+            </Text>
 
-              <BlankLink href={userInfo.introduction.blogUrl} target="_blank">
+            {userInfo.introduction.blogUrl && (
+              <BlankLink>
                 <AiFillCaretRight size={24} />
               </BlankLink>
-            </ContactContainer>
-          )}
+            )}
+          </ContactContainer>
         </BorderContainer>
 
-        {userInfo.introduction.description && (
-          <BorderContainer height={480}>
-            <MarkdownEditor
-              editorRef={null}
-              isViewMode
-              value={userInfo.introduction.description}
-            />
-          </BorderContainer>
-        )}
+        <DescriptionBorderContainer height={560}>
+          <Text size={20} strong>
+            자기소개
+          </Text>
 
-        <BorderContainer height={560}>
+          {!userInfo.introduction.description && (
+            <EmptyTextWrapper>
+              <Text size={16} strong>
+                아직 자기소개를 입력하지 않았어요
+              </Text>
+            </EmptyTextWrapper>
+          )}
+
+          <MarkdownEditor
+            editorRef={null}
+            isViewMode
+            value={userInfo.introduction.description}
+          />
+        </DescriptionBorderContainer>
+
+        <BorderContainer height={640}>
+          <Text size={20} strong>
+            내 위치
+          </Text>
+
           <StyledMap
             center={{
               lat: userInfo.introduction.latitude || common.defaultPosition.lat,
@@ -183,9 +219,9 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
         </BorderContainer>
 
         <BorderContainer height={560}>
-          <IconWrapper>
-            <MdModeComment size={24} />
-          </IconWrapper>
+          <Text size={20} strong>
+            댓글
+          </Text>
 
           {userInfo.comments?.length === 0 && (
             <CommentContainer>{`${userInfo.user.name}님에게 제일 먼저 댓글을 달아주세요!`}</CommentContainer>

--- a/src/components/UserDetail/styles.ts
+++ b/src/components/UserDetail/styles.ts
@@ -177,3 +177,9 @@ export const EmptyTextWrapper = styled.div`
   margin-top: auto;
   margin-bottom: auto;
 `;
+
+export const EllipsisWrapper = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+`;

--- a/src/components/UserDetail/styles.ts
+++ b/src/components/UserDetail/styles.ts
@@ -108,10 +108,6 @@ export const ContactContainer = styled.a`
     color: black;
     text-decoration: none;
   }
-
-  & > svg {
-    margin-right: 36px;
-  }
 `;
 
 export const BlankLink = styled.a`
@@ -140,8 +136,8 @@ export const CommentContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  overflow-y: auto;
   gap: 16px 0;
+  height: auto;
 `;
 
 export const FormContainer = styled.form`
@@ -173,6 +169,7 @@ export const HiddenLabel = styled.label`
 
 export const IconWrapper = styled.div`
   height: 24px;
+  margin-right: 36px;
 `;
 
 export const EmptyTextWrapper = styled.div`

--- a/src/components/UserDetail/styles.ts
+++ b/src/components/UserDetail/styles.ts
@@ -78,12 +78,36 @@ export const BorderContainer = styled.div<{ height?: number }>`
   min-width: 500px;
   gap: 32px;
   height: ${({ height }) => (height ? `${height}px` : "auto")};
-  overflow-y: auto;
 `;
 
-export const ContactContainer = styled.div`
+export const DescriptionBorderContainer = styled(BorderContainer)`
+  min-height: 560px;
+  height: auto;
+`;
+
+export const CommentBorderContainer = styled(BorderContainer)`
+  overflow-y: auto;
+  min-height: 560px;
+  height: auto;
+`;
+
+export const ContactContainer = styled.a`
   display: flex;
   align-items: center;
+  cursor: pointer;
+
+  &:link {
+    color: black;
+    text-decoration: none;
+  }
+  &:visited {
+    color: black;
+    text-decoration: none;
+  }
+  &:hover {
+    color: black;
+    text-decoration: none;
+  }
 
   & > svg {
     margin-right: 36px;
@@ -149,4 +173,10 @@ export const HiddenLabel = styled.label`
 
 export const IconWrapper = styled.div`
   height: 24px;
+`;
+
+export const EmptyTextWrapper = styled.div`
+  align-self: center;
+  margin-top: auto;
+  margin-bottom: auto;
 `;

--- a/src/components/UserDetail/styles.ts
+++ b/src/components/UserDetail/styles.ts
@@ -17,8 +17,17 @@ export const Container = styled.div`
   align-items: center;
   gap: 16px 0;
   width: 100%;
+  height: 100%;
   padding: 20px;
   overflow-y: auto;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px 0;
 `;
 
 export const ProfileImage = styled.img`
@@ -54,7 +63,7 @@ export const MbtiTag = styled(UserTag)`
 
 export const TextWrapper = styled.div`
   display: flex;
-  width: 50%;
+  width: 60%;
   justify-content: center;
   align-items: center;
 `;
@@ -65,7 +74,7 @@ export const BorderContainer = styled.div<{ height?: number }>`
   box-shadow: ${({ theme }) => theme.boxShadows.primary};
   border-radius: 20px;
   padding: 32px;
-  width: 50%;
+  width: 60%;
   min-width: 500px;
   gap: 32px;
   height: ${({ height }) => (height ? `${height}px` : "auto")};

--- a/src/components/UserList/styles.ts
+++ b/src/components/UserList/styles.ts
@@ -13,13 +13,14 @@ export const Container = styled.div`
 export const UserContainer = styled.div`
   display: grid;
   gap: 32px;
+  place-items: center;
 
   ${mediaQueriesBreakpoints.mobile} {
     grid-template-columns: repeat(1, 1fr);
   }
 
   ${mediaQueriesBreakpoints.tablet} {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 
   ${mediaQueriesBreakpoints.desktop} {
@@ -27,11 +28,11 @@ export const UserContainer = styled.div`
   }
 
   ${mediaQueriesBreakpoints.middleDesktop} {
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 
   ${mediaQueriesBreakpoints.largeDesktop} {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(5, 1fr);
   }
 
   grid-auto-rows: 360px;
@@ -92,6 +93,7 @@ export const ButtonWrapper = styled.div`
 export const ProfileCardWrapper = styled.div`
   display: flex;
   justify-content: center;
+  width: 220px;
 `;
 
 export const NotFoundResult = styled.div`


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

레이아웃 피드백 반영

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #154 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- 내 프로필
  - [x] 제목 추가
  - [x] 프로필사진에 + 버튼 추가
  - [x] 자기소개 height 크기 증가

- 데둥이 소개 페이지
  - [x] 레이아웃 깨지는 현상 수정
  - [x] 데둥이 리스트 그리드 레이아웃 수정
  - [x] 자기소개 스크롤 생기지 않도록 함
  - [x] 각 항목에 제목 추가
  - [x] 댓글 항목의 제목은 아이콘에서 텍스트로 변경
  - [x] 깃허브, 블로그 주소를 입력하지 않아도 화면상에 보이게 변경
  - [x] 댓글 입력 폼을 상단으로 옮김 (최신 댓글이 위로 오기 때문)
  - [x] 댓글 부분에도 스크롤 생기지 않도록 함
  - [x] 댓글 fromNow 추가

- 맵각코
  - [x] 맵각코 등록 모달 height 증가 

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

- 마이프로필

https://user-images.githubusercontent.com/52060742/146709894-4fbc6d51-3f2d-4d2f-8793-9c8953c447b5.mp4




- 데둥이 상세 페이지

https://user-images.githubusercontent.com/52060742/146709588-0eb0397b-282e-49a7-b84a-974ee92154d0.mp4



- 맵각코 등록 모달 height 증가
![image](https://user-images.githubusercontent.com/52060742/146709443-6b36571d-4e32-425b-86ef-c189736ee893.png)



## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 
