### PR TITLE
DVT-#166 맵각코 페이지에서 데둥이 조회 API 연동

### DIFF
--- a/src/components/Mapbox/customOverlayMarker.scss
+++ b/src/components/Mapbox/customOverlayMarker.scss
@@ -4,7 +4,7 @@ $marker-color: #d22b05;
 $marker--blue-color: #4169e0;
 $marker--green-color: #90EE90;
 
-.marker, .marker--blue, .marker--green {
+.marker, .marker--red, .marker--blue, .marker--green {
   position: relative;
   width: $marker-size;
   height: $marker-size;
@@ -18,6 +18,19 @@ $marker--green-color: #90EE90;
   pointer-events: none;
 
   &::before {
+    content: "";
+    position: absolute;
+    width: $marker-size;
+    height: $marker-size;
+    border: $border-width solid $marker-color;
+    box-sizing: border-box;
+    background-color: $marker-color;
+    border-radius: 50% 50% 0 50%;
+    transform: rotate(45deg);
+    z-index: 9;
+  }
+
+  &--before {
     content: "";
     position: absolute;
     width: $marker-size;

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { BsArrowRightCircle } from "react-icons/bs";
 import { Map, MapMarker } from "react-kakao-maps-sdk";
-import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import theme from "../../assets/theme";
 import useMapClick from "../../hooks/useMapClick";
 import { Position } from "../../types/commonTypes";
@@ -27,14 +26,15 @@ import {
 import MapgakcoMarker from "./MapgakcoMarker/MapgakcoMarker";
 import UserMarker from "./UserMarker";
 import MapgakcoDetailContainer from "./MapgakcoDetail/MapgakcoDetailContainer";
+import { ResponseUserLocation } from "../../types/userLocation";
 
 interface Props {
   initialCenter: Position;
-  userMapInfos: UserMapInfo[];
+  usersLocations: ResponseUserLocation[];
   mapgakcos: Mapgakco[];
 }
 
-const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
+const MapgakcoMap = ({ initialCenter, usersLocations, mapgakcos }: Props) => {
   const memoCenter = useRef(initialCenter);
 
   const [userClickPosition, click, initializeClick] = useMapClick();
@@ -95,7 +95,7 @@ const MapgakcoMap = ({ initialCenter, userMapInfos, mapgakcos }: Props) => {
     });
   }, []);
 
-  const userMarkerOverlays = getUserMarkerOverlays(userMapInfos);
+  const userMarkerOverlays = getUserMarkerOverlays(usersLocations);
   const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
 
   const handleRegisterModalClose = useCallback(() => {

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -27,14 +27,21 @@ import MapgakcoMarker from "./MapgakcoMarker/MapgakcoMarker";
 import UserMarker from "./UserMarker";
 import MapgakcoDetailContainer from "./MapgakcoDetail/MapgakcoDetailContainer";
 import { ResponseUserLocation } from "../../types/userLocation";
+import { UserData } from "../MyProfile/types";
 
 interface Props {
   initialCenter: Position;
-  usersLocations: ResponseUserLocation[];
   mapgakcos: Mapgakco[];
+  usersLocations: ResponseUserLocation[];
+  currentUser: UserData;
 }
 
-const MapgakcoMap = ({ initialCenter, usersLocations, mapgakcos }: Props) => {
+const MapgakcoMap = ({
+  initialCenter,
+  mapgakcos,
+  usersLocations,
+  currentUser,
+}: Props) => {
   const memoCenter = useRef(initialCenter);
 
   const [userClickPosition, click, initializeClick] = useMapClick();
@@ -95,7 +102,7 @@ const MapgakcoMap = ({ initialCenter, usersLocations, mapgakcos }: Props) => {
     });
   }, []);
 
-  const userMarkerOverlays = getUserMarkerOverlays(usersLocations);
+  const userMarkerOverlays = getUserMarkerOverlays(usersLocations, currentUser);
   const mapgakcoMarkerOverlays = getMapgakcoMarkerOverlays(mapgakcos);
 
   const handleRegisterModalClose = useCallback(() => {
@@ -272,13 +279,14 @@ const MapgakcoMap = ({ initialCenter, usersLocations, mapgakcos }: Props) => {
 
         {visibleUsers &&
           userMarkerOverlays.map(
-            ({ position, imageUrl, options: { text } }, index) => (
+            ({ position, imageUrl, options: { color, text } }, index) => (
               <UserMarker
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
                 position={position}
                 imageUrl={imageUrl}
                 text={text}
+                color={color}
               />
             )
           )}

--- a/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
@@ -40,6 +40,7 @@ const MapgakcoMapContainer = () => {
       initialCenter={center}
       usersLocations={usersLocations}
       mapgakcos={mapgakcos}
+      currentUser={currentUser}
     />
   );
 };

--- a/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMapContainer.tsx
@@ -1,15 +1,22 @@
 import { useRecoilValue } from "recoil";
-import randomUserMapInfo from "../../../fixtures/userMapInfo";
 import { globalMyProfile } from "../../atoms/user";
-import { common, COORDS } from "../../constants";
+import { common, COORDS, CourseKeyType } from "../../constants";
 import useMapgakcosQuery from "../../hooks/useMapgakcosQuery";
+import useUsersLocationsQuery from "../../hooks/useUsersLocationsQuery";
 import MapgakcoMap from "./MapgakcoMap";
 
 const MapgakcoMapContainer = () => {
   const currentUser = useRecoilValue(globalMyProfile);
 
-  // TODO: 빠른 개발을 위해 모킹 데이터를 쓰고 있다. 추후 데둥이 조회 API로 교체한다.
-  const userMapInfos = Array.from({ length: 120 }, () => randomUserMapInfo());
+  const { data: usersLocations } = useUsersLocationsQuery({
+    // TODO: 빠른 개발을 위해 대한민국 전체 좌표 범위를 사용한다. 사용자가 지도의 범위를 수정하면 해당하는 좌표 범위만 보여주도록 하는 기능을 추후 도입한다.
+    course: (currentUser?.user?.course as CourseKeyType) || "FE",
+    generation: currentUser?.user?.generation,
+    currentNEY: COORDS.KOREA_NEY,
+    currentNEX: COORDS.KOREA_NEX,
+    currentSWY: COORDS.KOREA_SWY,
+    currentSWX: COORDS.KOREA_SWX,
+  });
 
   const center = {
     lat: currentUser?.introduction?.latitude || common.defaultPosition.lat,
@@ -31,7 +38,7 @@ const MapgakcoMapContainer = () => {
   return (
     <MapgakcoMap
       initialCenter={center}
-      userMapInfos={userMapInfos}
+      usersLocations={usersLocations}
       mapgakcos={mapgakcos}
     />
   );

--- a/src/components/MapgakcoMap/UserMarker.tsx
+++ b/src/components/MapgakcoMap/UserMarker.tsx
@@ -5,16 +5,17 @@ interface Props {
   position: Position;
   imageUrl: string;
   text: string;
+  color?: string;
 }
 
-const UserMarker = ({ position, imageUrl, text }: Props) => {
+const UserMarker = ({ position, imageUrl, text, color = "blue" }: Props) => {
   return (
     <CustomOverlayMap
       clickable
       position={{ lat: position.lat, lng: position.lng }}
       yAnchor={1}
     >
-      <div className="marker--blue">
+      <div className={`marker--${color}`}>
         <img className="marker__image" src={imageUrl} alt="유저 이미지" />
         <span className="marker__text">{text}</span>
       </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import Lottie from "react-lottie";
 import { useRecoilValue } from "recoil";
+import { useLocation } from "react-router-dom";
 import animationData from "../../assets/lotties/christmas-dog.json";
 import {
   Container,
@@ -16,12 +17,15 @@ import menuRoutes from "./menuRoutes";
 import { routes } from "../../constants";
 import SidebarIcon from "./SidebarIcon";
 import { globalMyProfile } from "../../atoms";
+import theme from "../../assets/theme";
 
 interface Props {
   onLinkClick: (link: string) => void;
 }
 
 const Sidebar = ({ onLinkClick }: Props) => {
+  const { pathname } = useLocation();
+
   const handleClick = useCallback(
     (link) => (event: React.MouseEvent | React.KeyboardEvent) => {
       event.preventDefault();
@@ -84,6 +88,9 @@ const Sidebar = ({ onLinkClick }: Props) => {
                   onKeyPress={handleClick(path)}
                   role="presentation"
                   title={name}
+                  style={{
+                    backgroundColor: path === pathname && theme.colors.gray100,
+                  }}
                 >
                   <div>
                     <SidebarIcon name={name} />

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -83,6 +83,7 @@ const Sidebar = ({ onLinkClick }: Props) => {
                   onClick={handleClick(path)}
                   onKeyPress={handleClick(path)}
                   role="presentation"
+                  title={name}
                 >
                   <div>
                     <SidebarIcon name={name} />

--- a/src/components/Sidebar/styles.ts
+++ b/src/components/Sidebar/styles.ts
@@ -58,7 +58,7 @@ export const Nav = styled.div`
     }
 
     &:hover {
-      background-color: ${({ theme }) => theme.colors.gray100};
+      background-color: ${({ theme }) => theme.colors.gray300};
     }
 
     div {

--- a/src/components/UserImageAndDropdown/UserImageAndDropdown.test.tsx
+++ b/src/components/UserImageAndDropdown/UserImageAndDropdown.test.tsx
@@ -6,18 +6,12 @@ import theme from "../../assets/theme";
 import UserImageAndDropdown from "./UserImageAndDropdown";
 
 describe("UserImageAndDropdown", () => {
-  const handleImageClick = jest.fn();
   const handleLinkClick = jest.fn();
 
-  function renderUserImageAndDropdown({ isTriggered }) {
+  function renderUserImageAndDropdown() {
     return render(
       <ThemeProvider theme={theme}>
-        <UserImageAndDropdown
-          imageUrl=""
-          isTriggered={isTriggered}
-          onImageClick={handleImageClick}
-          onLinkClick={handleLinkClick}
-        />
+        <UserImageAndDropdown imageUrl="" onLinkClick={handleLinkClick} />
       </ThemeProvider>
     );
   }
@@ -26,50 +20,42 @@ describe("UserImageAndDropdown", () => {
     jest.clearAllMocks();
   });
 
-  it("유저 프로필 이미지를 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
-    renderUserImageAndDropdown({ isTriggered: false });
+  it("유저 프로필 이미지를 마우스 오버하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
+    renderUserImageAndDropdown();
 
     const profileImage = screen.getByAltText("유저 프로필 이미지");
-
-    userEvent.click(profileImage);
+    userEvent.hover(profileImage);
 
     expect(screen.queryByText("프로필")).toBeVisible();
     expect(screen.queryByText("내 모임 관리")).toBeVisible();
     expect(screen.queryByText("로그아웃")).toBeVisible();
   });
 
-  it("유저 프로필 이미지를 두 번 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 없다.", () => {
-    renderUserImageAndDropdown({ isTriggered: false });
+  it("드랍다운 메뉴에서 프로필을 마우스 오버하면, 자기소개 상세 조회 페이지로 이동한다", () => {
+    renderUserImageAndDropdown();
 
     const profileImage = screen.getByAltText("유저 프로필 이미지");
-
-    userEvent.click(profileImage);
-    userEvent.click(profileImage);
-
-    expect(screen.getByTestId("user-dropdown-menu")).toHaveStyle(
-      "max-height: 0"
-    );
-  });
-
-  it("드랍다운 메뉴에서 프로필을 클릭하면, 자기소개 상세 조회 페이지로 이동한다", () => {
-    renderUserImageAndDropdown({ isTriggered: true });
-
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("프로필"));
 
     expect(handleLinkClick).toBeCalledWith("/myprofile");
   });
 
-  it("드랍다운 메뉴에서 내 모임 관리를 클릭하면, 내 모임 관리 페이지로 이동한다", () => {
-    renderUserImageAndDropdown({ isTriggered: true });
+  it("드랍다운 메뉴에서 내 모임 관리를 마우스 오버하면, 내 모임 관리 페이지로 이동한다", () => {
+    renderUserImageAndDropdown();
 
+    const profileImage = screen.getByAltText("유저 프로필 이미지");
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("내 모임 관리"));
 
     expect(handleLinkClick).toBeCalledWith("/mygatherlist");
   });
 
-  it("드랍다운 메뉴에서 로그아웃을 클릭하면, 로그아웃이 되며 로그인 페이지로 이동한다", () => {
-    renderUserImageAndDropdown({ isTriggered: true });
+  it("드랍다운 메뉴에서 로그아웃을 마우스 오버하면, 로그아웃이 되며 로그인 페이지로 이동한다", () => {
+    renderUserImageAndDropdown();
 
+    const profileImage = screen.getByAltText("유저 프로필 이미지");
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("로그아웃"));
 
     expect(handleLinkClick).toBeCalledWith("/logout");

--- a/src/components/UserImageAndDropdown/UserImageAndDropdown.tsx
+++ b/src/components/UserImageAndDropdown/UserImageAndDropdown.tsx
@@ -1,27 +1,23 @@
+import useHover from "../../hooks/useHover";
 import UserDropdownMenu from "../UserDropdownMenu/UserDropdownMenu";
 import UserProfileImage from "../UserProfileImage/UserProfileImage";
 import { Container, DropdownWrapper, ImageWrapper } from "./styles";
 
 interface Props {
   imageUrl: string;
-  isTriggered: boolean;
-  onImageClick: (event: React.MouseEvent) => void;
   onLinkClick: (link: string) => void;
 }
 
-const UserImageAndDropdown = ({
-  imageUrl,
-  isTriggered,
-  onImageClick,
-  onLinkClick,
-}: Props) => {
+const UserImageAndDropdown = ({ imageUrl, onLinkClick }: Props) => {
+  const [ref, isHovered] = useHover();
+
   return (
     <Container>
-      <ImageWrapper onClick={onImageClick}>
+      <ImageWrapper ref={ref}>
         <UserProfileImage imageUrl={imageUrl} />
       </ImageWrapper>
       <DropdownWrapper>
-        <UserDropdownMenu isTriggered={isTriggered} onLinkClick={onLinkClick} />
+        <UserDropdownMenu isTriggered={isHovered} onLinkClick={onLinkClick} />
       </DropdownWrapper>
     </Container>
   );

--- a/src/components/UserImageAndDropdown/UserImageAndDropdownContainer.test.tsx
+++ b/src/components/UserImageAndDropdown/UserImageAndDropdownContainer.test.tsx
@@ -37,40 +37,34 @@ describe("UserImageAndDropdownContainer", () => {
     );
   });
 
-  it("유저 프로필 이미지를 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
+  it("유저 프로필 이미지를 마우스 오버하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
     const profileImage = screen.getByAltText("유저 프로필 이미지");
-
-    userEvent.click(profileImage);
+    userEvent.hover(profileImage);
 
     expect(screen.queryByText("프로필")).toBeVisible();
     expect(screen.queryByText("내 모임 관리")).toBeVisible();
     expect(screen.queryByText("로그아웃")).toBeVisible();
   });
 
-  it("유저 프로필 이미지를 두 번 클릭하면, `프로필`, `내 모임 관리`, `로그아웃` 메뉴를 볼 수 있다.", () => {
-    const profileImage = screen.getByAltText("유저 프로필 이미지");
-
-    userEvent.click(profileImage);
-    userEvent.click(profileImage);
-
-    expect(screen.getByTestId("user-dropdown-menu")).toHaveStyle(
-      "max-height: 0"
-    );
-  });
-
   it("드랍다운 메뉴에서 프로필을 클릭하면, 자기소개 상세 조회 페이지로 이동한다", () => {
+    const profileImage = screen.getByAltText("유저 프로필 이미지");
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("프로필"));
 
     expect(mockPush).toBeCalledWith(routes.MYPROFILE);
   });
 
   it("드랍다운 메뉴에서 내 모임 관리를 클릭하면, 내 모임 관리 페이지로 이동한다", () => {
+    const profileImage = screen.getByAltText("유저 프로필 이미지");
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("내 모임 관리"));
 
     expect(mockPush).toBeCalledWith(routes.MYGATHERLIST);
   });
 
   it("드랍다운 메뉴에서 로그아웃을 클릭하면, 로그아웃이 되며 로그인 페이지로 이동한다", () => {
+    const profileImage = screen.getByAltText("유저 프로필 이미지");
+    userEvent.hover(profileImage);
     userEvent.click(screen.getByText("로그아웃"));
 
     // TODO: 로그아웃을 테스트하기 위해 useLocalStorage 훅 테스트를 하거나 localStorage.setItem spyOn으로 추적하여 테스트를 한다

--- a/src/components/UserImageAndDropdown/UserImageAndDropdownContainer.tsx
+++ b/src/components/UserImageAndDropdown/UserImageAndDropdownContainer.tsx
@@ -4,7 +4,6 @@ import { useRecoilState } from "recoil";
 import { globalMyProfile } from "../../atoms";
 import { login, routes } from "../../constants";
 import { useLocalStorage } from "../../hooks";
-import useToggle from "../../hooks/useToggle";
 import UserImageAndDropdown from "./UserImageAndDropdown";
 
 interface Props {
@@ -15,8 +14,6 @@ const UserImageAndDropdownContainer = ({ imageUrl }: Props) => {
   const history = useHistory();
 
   const [, setToken] = useLocalStorage(login.localStorageKey.TOKEN, "");
-
-  const [isTriggered, toggle] = useToggle(false);
 
   const [, setGlobalMyProfile] = useRecoilState(globalMyProfile);
 
@@ -36,12 +33,7 @@ const UserImageAndDropdownContainer = ({ imageUrl }: Props) => {
   );
 
   return (
-    <UserImageAndDropdown
-      imageUrl={imageUrl}
-      isTriggered={isTriggered}
-      onImageClick={toggle}
-      onLinkClick={handleLinkClick}
-    />
+    <UserImageAndDropdown imageUrl={imageUrl} onLinkClick={handleLinkClick} />
   );
 };
 

--- a/src/components/UsersMap/UsersMap.tsx
+++ b/src/components/UsersMap/UsersMap.tsx
@@ -1,38 +1,132 @@
+import { Map } from "react-kakao-maps-sdk";
+import { courses, generations, roles } from "../../../fixtures/selectDatas";
 import { common } from "../../constants";
+import { Formik } from "../../hooks/useUsersLocationsFormik";
 import { Position } from "../../types/commonTypes";
 import { ResponseUserLocation } from "../../types/userLocation";
-import Mapbox from "../Mapbox/Mapbox";
+import { getUserMarkerOverlays } from "../../utils/map/overlay";
+import Input from "../base/Input";
+import Text from "../base/Text";
+import { Container, MapFloatContainer } from "../MapgakcoMap/styles";
+import UserMarker from "../MapgakcoMap/UserMarker";
+import { UserData } from "../MyProfile/types";
+import {
+  Button,
+  ButtonWrapper,
+  InputWrapper,
+  SearchBarFormContainer,
+  Select,
+} from "../UserList/styles";
 
 interface Props {
   center: Position;
-  userImageUrl: string;
   usersLocations?: ResponseUserLocation[];
+  currentUser: UserData;
+  formik: Formik;
 }
 
-const UsersMap = ({ center, userImageUrl, usersLocations }: Props) => {
-  const imageMarkerOverlays = (usersLocations || []).map((userLocation) => {
-    const position = {
-      lat: userLocation?.latitude,
-      lng: userLocation?.longitude,
-    };
-
-    const imageUrl = userLocation.profileImgUrl;
-
-    const options = {
-      color: "blue",
-      text: userLocation.name,
-    };
-
-    return { position, imageUrl, options };
-  });
+const UsersMap = ({ center, usersLocations, currentUser, formik }: Props) => {
+  const userMarkerOverlays = getUserMarkerOverlays(usersLocations, currentUser);
 
   return (
-    <Mapbox
-      center={{ lat: center.lat, lng: center.lng }}
-      hasCenterMarker
-      userImageUrl={userImageUrl || common.placeHolderImageSrc}
-      imageMarkerOverlays={imageMarkerOverlays}
-    />
+    <Container>
+      <MapFloatContainer>
+        <SearchBarFormContainer onSubmit={formik.handleSubmit}>
+          <InputWrapper>
+            <Select
+              id="generation"
+              name="generation"
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              value={formik.values.generation}
+            >
+              <option value="">{common.text.GENERATION}</option>
+              {generations.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </Select>
+            <Select
+              id="course"
+              name="course"
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              value={formik.values.course}
+            >
+              <option value="">{common.text.COURSE}</option>
+              {courses.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </Select>
+            <Select
+              id="role"
+              name="role"
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              value={formik.values.role}
+            >
+              <option value="">{common.text.ROLE}</option>
+              {roles.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </Select>
+            <Input
+              type="text"
+              name="name"
+              placeholder={common.message.ENTER_SEARCH_TERM}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              value={formik.values.name}
+            />
+          </InputWrapper>
+
+          <ButtonWrapper>
+            <Button type="submit">
+              <Text size={12} color="white" strong ellipsisLineClamp={1}>
+                {common.text.SEARCH}
+              </Text>
+            </Button>
+          </ButtonWrapper>
+        </SearchBarFormContainer>
+      </MapFloatContainer>
+      <Map
+        center={{
+          lat: center.lat,
+          lng: center.lng,
+        }}
+        style={{
+          width: "100%",
+          height: "100%",
+        }}
+        level={4}
+      >
+        {true &&
+          userMarkerOverlays.map(
+            ({ position, imageUrl, options: { color, text } }, index) => (
+              <UserMarker
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                position={position}
+                imageUrl={imageUrl}
+                text={text}
+                color={color}
+              />
+            )
+          )}
+      </Map>
+    </Container>
+
+    // <Mapbox
+    //   center={{ lat: center.lat, lng: center.lng }}
+    //   hasCenterMarker
+    //   userImageUrl={userImageUrl || common.placeHolderImageSrc}
+    //   imageMarkerOverlays={imageMarkerOverlays}
+    // />
   );
 };
 

--- a/src/components/UsersMap/UsersMap.tsx
+++ b/src/components/UsersMap/UsersMap.tsx
@@ -1,18 +1,15 @@
 import { Map } from "react-kakao-maps-sdk";
-import { courses, generations, roles } from "../../../fixtures/selectDatas";
-import { common } from "../../constants";
-import { Formik } from "../../hooks/useUsersLocationsFormik";
+import { useQueryClient } from "react-query";
+import { courses, generations } from "../../../fixtures/selectDatas";
+import { common, COORDS, CourseKeyType } from "../../constants";
+import useUsersLocationsFormik from "../../hooks/useUsersLocationsFormik";
+import useUsersLocationsQuery from "../../hooks/useUsersLocationsQuery";
 import { Position } from "../../types/commonTypes";
-import { ResponseUserLocation } from "../../types/userLocation";
 import { getUserMarkerOverlays } from "../../utils/map/overlay";
-import Input from "../base/Input";
-import Text from "../base/Text";
 import { Container, MapFloatContainer } from "../MapgakcoMap/styles";
 import UserMarker from "../MapgakcoMap/UserMarker";
 import { UserData } from "../MyProfile/types";
 import {
-  Button,
-  ButtonWrapper,
   InputWrapper,
   SearchBarFormContainer,
   Select,
@@ -20,12 +17,37 @@ import {
 
 interface Props {
   center: Position;
-  usersLocations?: ResponseUserLocation[];
   currentUser: UserData;
-  formik: Formik;
 }
 
-const UsersMap = ({ center, usersLocations, currentUser, formik }: Props) => {
+const UsersMap = ({ center, currentUser }: Props) => {
+  const queryClient = useQueryClient();
+
+  const formik = useUsersLocationsFormik({
+    initialValues: {
+      name: "",
+      course: currentUser?.user?.course,
+      generation: currentUser?.user?.generation,
+      role: currentUser?.user?.role,
+    },
+    submitHandler: () => {
+      queryClient.invalidateQueries(["usersLocations", formik.values]);
+    },
+  });
+
+  const { data: usersLocations } = useUsersLocationsQuery({
+    // TODO: 빠른 개발을 위해 대한민국 전체 좌표 범위를 사용한다. 사용자가 지도의 범위를 수정하면 해당하는 좌표 범위만 보여주도록 하는 기능을 추후 도입한다.
+    course:
+      formik.values.course ||
+      (currentUser?.user?.course as CourseKeyType) ||
+      "FE",
+    generation: formik.values.generation || currentUser?.user?.generation,
+    currentNEY: COORDS.KOREA_NEY,
+    currentNEX: COORDS.KOREA_NEX,
+    currentSWY: COORDS.KOREA_SWY,
+    currentSWX: COORDS.KOREA_SWX,
+  });
+
   const userMarkerOverlays = getUserMarkerOverlays(usersLocations, currentUser);
 
   return (
@@ -61,7 +83,8 @@ const UsersMap = ({ center, usersLocations, currentUser, formik }: Props) => {
                 </option>
               ))}
             </Select>
-            <Select
+            {/* TODO: 명세가 확정되고 필요하면 역할별 검색 기능을 추가한다. */}
+            {/* <Select
               id="role"
               name="role"
               onChange={formik.handleChange}
@@ -74,24 +97,26 @@ const UsersMap = ({ center, usersLocations, currentUser, formik }: Props) => {
                   {label}
                 </option>
               ))}
-            </Select>
-            <Input
+            </Select> */}
+            {/* TODO: 명세가 확정되고 필요하면 이름 검색 기능을 추가한다. */}
+            {/* <Input
               type="text"
               name="name"
               placeholder={common.message.ENTER_SEARCH_TERM}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.name}
-            />
+            /> */}
           </InputWrapper>
 
-          <ButtonWrapper>
+          {/* TODO: 명세가 확정되고 필요하면 이름 검색 기능을 추가한다. */}
+          {/* <ButtonWrapper>
             <Button type="submit">
               <Text size={12} color="white" strong ellipsisLineClamp={1}>
                 {common.text.SEARCH}
               </Text>
             </Button>
-          </ButtonWrapper>
+          </ButtonWrapper> */}
         </SearchBarFormContainer>
       </MapFloatContainer>
       <Map

--- a/src/components/UsersMap/UsersMap.tsx
+++ b/src/components/UsersMap/UsersMap.tsx
@@ -1,26 +1,26 @@
-import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import { common } from "../../constants";
 import { Position } from "../../types/commonTypes";
+import { ResponseUserLocation } from "../../types/userLocation";
 import Mapbox from "../Mapbox/Mapbox";
 
 interface Props {
   center: Position;
   userImageUrl: string;
-  userMapInfos?: UserMapInfo[];
+  usersLocations?: ResponseUserLocation[];
 }
 
-const UsersMap = ({ center, userImageUrl, userMapInfos }: Props) => {
-  const imageMarkerOverlays = userMapInfos.map((userMapInfo) => {
+const UsersMap = ({ center, userImageUrl, usersLocations }: Props) => {
+  const imageMarkerOverlays = (usersLocations || []).map((userLocation) => {
     const position = {
-      lat: userMapInfo?.latitude,
-      lng: userMapInfo?.longitude,
+      lat: userLocation?.latitude,
+      lng: userLocation?.longitude,
     };
 
-    const imageUrl = userMapInfo.profileImgUrl;
+    const imageUrl = userLocation.profileImgUrl;
 
     const options = {
       color: "blue",
-      text: userMapInfo.name,
+      text: userLocation.name,
     };
 
     return { position, imageUrl, options };

--- a/src/components/UsersMap/UsersMapContainer.tsx
+++ b/src/components/UsersMap/UsersMapContainer.tsx
@@ -1,58 +1,17 @@
-import { useQueryClient } from "react-query";
 import { useRecoilValue } from "recoil";
 import { globalMyProfile } from "../../atoms/user";
-import { common, COORDS, CourseKeyType } from "../../constants";
-import useUsersLocationsFormik from "../../hooks/useUsersLocationsFormik";
-import useUsersLocationsQuery from "../../hooks/useUsersLocationsQuery";
+import { common } from "../../constants";
 import UsersMap from "./UsersMap";
 
 const UsersMapContainer = () => {
-  const queryClient = useQueryClient();
-
   const currentUser = useRecoilValue(globalMyProfile);
-
-  const formik = useUsersLocationsFormik({
-    initialValues: {
-      name: "",
-      course: "",
-      generation: "",
-      role: "",
-    },
-    submitHandler: () => {
-      queryClient.invalidateQueries("usersLocations");
-    },
-  });
-
-  const { isLoading, data: usersLocations } = useUsersLocationsQuery({
-    // TODO: 빠른 개발을 위해 대한민국 전체 좌표 범위를 사용한다. 사용자가 지도의 범위를 수정하면 해당하는 좌표 범위만 보여주도록 하는 기능을 추후 도입한다.
-    course:
-      formik.values.course ||
-      (currentUser?.user?.course as CourseKeyType) ||
-      "FE",
-    generation: formik.values.generation || currentUser?.user?.generation,
-    currentNEY: COORDS.KOREA_NEY,
-    currentNEX: COORDS.KOREA_NEX,
-    currentSWY: COORDS.KOREA_SWY,
-    currentSWX: COORDS.KOREA_SWX,
-  });
 
   const center = {
     lat: currentUser?.introduction?.latitude || common.defaultPosition.lat,
     lng: currentUser?.introduction?.longitude || common.defaultPosition.lng,
   };
 
-  if (isLoading) {
-    return null;
-  }
-
-  return (
-    <UsersMap
-      center={center}
-      usersLocations={usersLocations}
-      currentUser={currentUser}
-      formik={formik}
-    />
-  );
+  return <UsersMap center={center} currentUser={currentUser} />;
 };
 
 export default UsersMapContainer;

--- a/src/components/UsersMap/UsersMapContainer.tsx
+++ b/src/components/UsersMap/UsersMapContainer.tsx
@@ -1,16 +1,35 @@
+import { useQueryClient } from "react-query";
 import { useRecoilValue } from "recoil";
 import { globalMyProfile } from "../../atoms/user";
 import { common, COORDS, CourseKeyType } from "../../constants";
+import useUsersLocationsFormik from "../../hooks/useUsersLocationsFormik";
 import useUsersLocationsQuery from "../../hooks/useUsersLocationsQuery";
 import UsersMap from "./UsersMap";
 
 const UsersMapContainer = () => {
+  const queryClient = useQueryClient();
+
   const currentUser = useRecoilValue(globalMyProfile);
+
+  const formik = useUsersLocationsFormik({
+    initialValues: {
+      name: "",
+      course: "",
+      generation: "",
+      role: "",
+    },
+    submitHandler: () => {
+      queryClient.invalidateQueries("usersLocations");
+    },
+  });
 
   const { isLoading, data: usersLocations } = useUsersLocationsQuery({
     // TODO: 빠른 개발을 위해 대한민국 전체 좌표 범위를 사용한다. 사용자가 지도의 범위를 수정하면 해당하는 좌표 범위만 보여주도록 하는 기능을 추후 도입한다.
-    course: (currentUser?.user?.course as CourseKeyType) || "FE",
-    generation: currentUser?.user?.generation,
+    course:
+      formik.values.course ||
+      (currentUser?.user?.course as CourseKeyType) ||
+      "FE",
+    generation: formik.values.generation || currentUser?.user?.generation,
     currentNEY: COORDS.KOREA_NEY,
     currentNEX: COORDS.KOREA_NEX,
     currentSWY: COORDS.KOREA_SWY,
@@ -22,9 +41,6 @@ const UsersMapContainer = () => {
     lng: currentUser?.introduction?.longitude || common.defaultPosition.lng,
   };
 
-  const userImageUrl =
-    currentUser?.introduction?.profileImgUrl || common.placeHolderImageSrc;
-
   if (isLoading) {
     return null;
   }
@@ -32,8 +48,9 @@ const UsersMapContainer = () => {
   return (
     <UsersMap
       center={center}
-      userImageUrl={userImageUrl}
       usersLocations={usersLocations}
+      currentUser={currentUser}
+      formik={formik}
     />
   );
 };

--- a/src/components/UsersMap/UsersMapContainer.tsx
+++ b/src/components/UsersMap/UsersMapContainer.tsx
@@ -1,23 +1,39 @@
 import { useRecoilValue } from "recoil";
-import randomUserMapInfo from "../../../fixtures/userMapInfo";
-import { currentUserState } from "../../atoms/user";
-import { common } from "../../constants";
+import { globalMyProfile } from "../../atoms/user";
+import { common, COORDS, CourseKeyType } from "../../constants";
+import useUsersLocationsQuery from "../../hooks/useUsersLocationsQuery";
 import UsersMap from "./UsersMap";
 
 const UsersMapContainer = () => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValue(globalMyProfile);
 
-  const center = common.defaultPosition;
+  const { isLoading, data: usersLocations } = useUsersLocationsQuery({
+    // TODO: 빠른 개발을 위해 대한민국 전체 좌표 범위를 사용한다. 사용자가 지도의 범위를 수정하면 해당하는 좌표 범위만 보여주도록 하는 기능을 추후 도입한다.
+    course: (currentUser?.user?.course as CourseKeyType) || "FE",
+    generation: currentUser?.user?.generation,
+    currentNEY: COORDS.KOREA_NEY,
+    currentNEX: COORDS.KOREA_NEX,
+    currentSWY: COORDS.KOREA_SWY,
+    currentSWX: COORDS.KOREA_SWX,
+  });
 
-  const userImageUrl = currentUser?.introduction.profileImgUrl;
+  const center = {
+    lat: currentUser?.introduction?.latitude || common.defaultPosition.lat,
+    lng: currentUser?.introduction?.longitude || common.defaultPosition.lng,
+  };
 
-  const userMapInfos = Array.from({ length: 120 }, () => randomUserMapInfo());
+  const userImageUrl =
+    currentUser?.introduction?.profileImgUrl || common.placeHolderImageSrc;
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <UsersMap
       center={center}
       userImageUrl={userImageUrl}
-      userMapInfos={userMapInfos}
+      usersLocations={usersLocations}
     />
   );
 };

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -5,4 +5,5 @@ export const url = {
   GAHTER_SUGGESTIONS: `${VERSION}/gathers/suggest`,
   MAPGAKCOS: `${VERSION}/mapgakcos/`,
   MAPGAKCOS_RANGE: `${VERSION}/mapgakcos/range/`,
+  USERS_LOCATIONS_RANGE: `${VERSION}/users/locations/range/`,
 };

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState, useRef } from "react";
+
+const useHover = (): [typeof ref, typeof state] => {
+  const [state, setState] = useState(false);
+  const ref = useRef(null);
+
+  const handleMouseOver = useCallback(() => setState(true), []);
+  const handleMouseOut = useCallback(() => setState(false), []);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    element.addEventListener("mouseover", handleMouseOver);
+    element.addEventListener("mouseout", handleMouseOut);
+
+    return () => {
+      element.removeEventListener("mouseover", handleMouseOver);
+      element.removeEventListener("mouseout", handleMouseOut);
+    };
+  }, [ref, handleMouseOver, handleMouseOut]);
+
+  return [ref, state];
+};
+
+export default useHover;

--- a/src/hooks/useUsersLocationsFormik.ts
+++ b/src/hooks/useUsersLocationsFormik.ts
@@ -1,0 +1,36 @@
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { CourseKeyType, RoleKeyType } from "../constants";
+
+export interface FormValues {
+  name: string;
+  course: CourseKeyType;
+  generation: string;
+  role: RoleKeyType;
+}
+
+const useUsersLocationsFormik = ({
+  initialValues,
+  submitHandler,
+}): typeof formik => {
+  const formik = useFormik<FormValues>({
+    initialValues: {
+      name: initialValues.name || "",
+      course: initialValues.course || "",
+      generation: initialValues.generation || "",
+      role: initialValues.role || "",
+    },
+    validationSchema: Yup.string().required(""),
+    onSubmit: (formValues) => {
+      submitHandler({
+        ...formValues,
+      });
+    },
+  });
+
+  return formik;
+};
+
+export default useUsersLocationsFormik;
+
+export type Formik = ReturnType<typeof useUsersLocationsFormik>;

--- a/src/hooks/useUsersLocationsQuery.ts
+++ b/src/hooks/useUsersLocationsQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "react-query";
+import { RequestGetUsersLocations } from "../types/userLocation";
+import { requestGetUsersLocations } from "../utils/apis";
+
+const getUsersLocations = async (values: RequestGetUsersLocations) => {
+  const { data } = await requestGetUsersLocations(values);
+
+  return data?.data || [];
+};
+
+export default function useUsersLocationsQuery(
+  values: RequestGetUsersLocations,
+  interval = 0
+) {
+  return useQuery("usersLocations", () => getUsersLocations(values), {
+    refetchInterval: interval || false,
+  });
+}

--- a/src/hooks/useUsersLocationsQuery.ts
+++ b/src/hooks/useUsersLocationsQuery.ts
@@ -12,7 +12,7 @@ export default function useUsersLocationsQuery(
   values: RequestGetUsersLocations,
   interval = 0
 ) {
-  return useQuery("usersLocations", () => getUsersLocations(values), {
+  return useQuery(["usersLocations", values], () => getUsersLocations(values), {
     refetchInterval: interval || false,
   });
 }

--- a/src/types/userLocation.ts
+++ b/src/types/userLocation.ts
@@ -2,7 +2,7 @@ import { CourseKeyType } from "../constants";
 
 export interface RequestGetUsersLocations {
   course?: CourseKeyType;
-  generation?: number;
+  generation?: number | string;
   currentNEX: number;
   currentNEY: number;
   currentSWX: number;

--- a/src/types/userLocation.ts
+++ b/src/types/userLocation.ts
@@ -1,0 +1,20 @@
+import { CourseKeyType } from "../constants";
+
+export interface RequestGetUsersLocations {
+  course?: CourseKeyType;
+  generation?: number;
+  currentNEX: number;
+  currentNEY: number;
+  currentSWX: number;
+  currentSWY: number;
+}
+
+export interface ResponseUserLocation {
+  userId: number;
+  name: string;
+  course: CourseKeyType;
+  generation: number;
+  profileImgUrl: string;
+  latitude: number;
+  longitude: number;
+}

--- a/src/utils/apis/index.ts
+++ b/src/utils/apis/index.ts
@@ -12,3 +12,4 @@ export {
   requestPostMapgakcoApply,
   requestDeleteMapgakcoApply,
 } from "./mapgakco";
+export { requestGetUsersLocations } from "./user";

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -1,0 +1,16 @@
+import necessaryAuthAxiosInstance from "./necessaryAuthAxiosInstance";
+import { url, COORDS } from "../../constants";
+import { RequestGetUsersLocations } from "../../types/userLocation";
+
+export const requestGetUsersLocations = (values: RequestGetUsersLocations) => {
+  return necessaryAuthAxiosInstance.get(url.USERS_LOCATIONS_RANGE, {
+    params: {
+      course: values?.course || "",
+      generation: values?.generation || "",
+      currentNEX: values?.currentNEX || COORDS.KOREA_NEX,
+      currentNEY: values?.currentNEY || COORDS.KOREA_NEY,
+      currentSWX: values?.currentSWX || COORDS.KOREA_SWX,
+      currentSWY: values?.currentSWY || COORDS.KOREA_SWY,
+    },
+  });
+};

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -1,4 +1,5 @@
 import { UserData } from "../../components/MyProfile/types";
+import { common } from "../../constants";
 import { Mapgakco, Position } from "../../types/mapTypes";
 import { ResponseUserLocation } from "../../types/userLocation";
 import { koreanDate } from "../date";
@@ -176,7 +177,7 @@ export const getUserMarkerOverlays = (
       lng: userLocation?.longitude,
     };
 
-    const imageUrl = userLocation?.profileImgUrl;
+    const imageUrl = userLocation?.profileImgUrl || common.placeHolderImageSrc;
 
     const options = {
       color: userLocation?.userId === currentUser.user.userId ? "red" : "blue",

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -1,5 +1,5 @@
-import { UserMapInfo } from "../../../fixtures/userMapInfo";
 import { Mapgakco, Position } from "../../types/mapTypes";
+import { ResponseUserLocation } from "../../types/userLocation";
 import { koreanDate } from "../date";
 
 interface CustomOverlayProps {
@@ -165,18 +165,20 @@ export const addMapgakcoOverlay = ({ map, mapgakco }: MapgakcoOverlayProps) => {
 };
 
 // TODO: 리팩터링. getUserMarkerOverlays와 getMapgakcoMarkerOverlays를 하나의 함수로 처리한다.
-export const getUserMarkerOverlays = (userMapInfos: UserMapInfo[]) => {
-  return userMapInfos.map((userMapInfo) => {
+export const getUserMarkerOverlays = (
+  usersLocations: ResponseUserLocation[]
+) => {
+  return (usersLocations || []).map((userLocation) => {
     const position = {
-      lat: userMapInfo?.latitude,
-      lng: userMapInfo?.longitude,
+      lat: userLocation?.latitude,
+      lng: userLocation?.longitude,
     };
 
-    const imageUrl = userMapInfo.profileImgUrl;
+    const imageUrl = userLocation?.profileImgUrl;
 
     const options = {
       color: "blue",
-      text: userMapInfo.name,
+      text: userLocation?.name,
     };
 
     return { position, imageUrl, options };

--- a/src/utils/map/overlay.ts
+++ b/src/utils/map/overlay.ts
@@ -1,3 +1,4 @@
+import { UserData } from "../../components/MyProfile/types";
 import { Mapgakco, Position } from "../../types/mapTypes";
 import { ResponseUserLocation } from "../../types/userLocation";
 import { koreanDate } from "../date";
@@ -166,7 +167,8 @@ export const addMapgakcoOverlay = ({ map, mapgakco }: MapgakcoOverlayProps) => {
 
 // TODO: 리팩터링. getUserMarkerOverlays와 getMapgakcoMarkerOverlays를 하나의 함수로 처리한다.
 export const getUserMarkerOverlays = (
-  usersLocations: ResponseUserLocation[]
+  usersLocations: ResponseUserLocation[],
+  currentUser: UserData
 ) => {
   return (usersLocations || []).map((userLocation) => {
     const position = {
@@ -177,7 +179,7 @@ export const getUserMarkerOverlays = (
     const imageUrl = userLocation?.profileImgUrl;
 
     const options = {
-      color: "blue",
+      color: userLocation?.userId === currentUser.user.userId ? "red" : "blue",
       text: userLocation?.name,
     };
 


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

맵각코 페이지에서 데둥이 조회 API 연동한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #166 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x]  데둥이 조회 API 연동
- [x] 데둥여지도에도 함께 반영
- [x] 현재 URL과 일치하는 사이드바 메뉴에 배경색 적용
- [x] 탑바 유저 드랍다운 메뉴를 마우스 오버(호버) 방식으로 변경

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

![image](https://user-images.githubusercontent.com/8105528/146846639-04546187-9c23-4edb-978b-714c51e02903.png)

- 사용자가 보고 있는 페이지와 일치하는 사이드바 메뉴에 배경색 적용

![image](https://user-images.githubusercontent.com/8105528/146846698-39e80642-73b9-4122-adeb-9c99e2f37d1f.png)

- 데둥여지도에 필터링 기능 추가

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- 데둥여지도 부분은 피드백 내용과 API 명세가 일치하지 않는 부분이 있어 확인 후 추가 작업이 있을 수 있습니다.
- 데둥여지도에서 사용자의 기수, 코스별로 필터링하는 부분은 데둥이 소개에 있는 컴포넌트를 그대로 재활용 하였습니다. 따라서 데둥여지도 페이지의 해당 컴포넌트가 업데이트 될 경우 함께 업데이트 될 수 있습니다.
