### PR TITLE
DVT-#172 레이아웃 다듬기

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "react-markdown": "^7.1.1",
     "react-query": "^3.34.0",
     "react-router-dom": "^5.3.0",
+    "react-scroll-horizontal": "^1.6.6",
     "react-toastify": "^8.1.0",
     "recoil": "^0.5.2",
     "yup": "^0.32.11"

--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -29,6 +29,7 @@ const theme = {
     coral: "#ffb09b",
     olive: "#d8c573",
     skyblue: "#66b3ff",
+    blue: "#0457e7",
     mint: "#66ffb2",
     scarlet: "#ff6667",
     yellow: "#ffff66",

--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -1,8 +1,4 @@
 import { FormikProps, useFormik } from "formik";
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import relativeTime from "dayjs/plugin/relativeTime";
-import { useEffect } from "react";
 import { adminValidator } from "../../utils/yups/admin";
 import {
   BorderContainer,
@@ -24,7 +20,7 @@ import Text from "../base/Text";
 import useMutationInviteLink from "../../hooks/useMutationInviteLink";
 import useQueryInviteLink from "../../hooks/useQueryInviteLink";
 import useCopyClipboard from "../../hooks/useCopyClipboard";
-import useCustomToast from "../../hooks/useCustomToast";
+import useDayjs from "../../hooks/useDayjs";
 
 interface FormValues {
   course: string;
@@ -37,7 +33,7 @@ const Admin = () => {
   const { data } = useQueryInviteLink();
   const { mutate } = useMutationInviteLink();
 
-  const [toast] = useCustomToast();
+  const [dayjs] = useDayjs();
 
   const {
     handleSubmit,
@@ -59,16 +55,10 @@ const Admin = () => {
       });
       setSubmitting(false);
       resetForm();
-      toast({ message: "링크 생성이 완료되었습니다 😄" });
     },
   });
 
   const [handleCopyClick] = useCopyClipboard();
-
-  useEffect(() => {
-    dayjs.extend(relativeTime);
-    dayjs.extend(customParseFormat);
-  }, []);
 
   return (
     <Container>

--- a/src/components/GatherDetail/Comment/index.tsx
+++ b/src/components/GatherDetail/Comment/index.tsx
@@ -3,8 +3,6 @@ import { useRecoilValue } from "recoil";
 import { useCallback, useEffect, useState } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
 import {
   Container,
   ButtonContainer,
@@ -27,7 +25,7 @@ import Input from "../../base/Input";
 import useDeleteComment from "../../../hooks/useDeleteComment";
 import useCreateGatherComment from "../../../hooks/useCreateGatherComment";
 import useEditComment from "../../../hooks/useEditComment";
-import "dayjs/locale/ko";
+import useDayjs from "../../../hooks/useDayjs";
 
 interface IProps {
   comment: Comment;
@@ -37,6 +35,8 @@ interface IProps {
 
 const Comment = ({ comment, isChild, gatherId }: IProps) => {
   const [fromNow, setFromNow] = useState<string | null>(null);
+
+  const [dayjs] = useDayjs();
 
   const myProfile = useRecoilValue(globalMyProfile);
 
@@ -119,10 +119,8 @@ const Comment = ({ comment, isChild, gatherId }: IProps) => {
   );
 
   useEffect(() => {
-    dayjs.extend(relativeTime);
-    dayjs.locale("ko");
-    setFromNow(dayjs(comment.modifiedAt).fromNow());
-  }, [comment]);
+    setFromNow(dayjs(comment.modifiedAt).subtract(5, "second").fromNow());
+  }, [comment, dayjs]);
 
   return (
     <Container>

--- a/src/components/Main/Main.test.tsx
+++ b/src/components/Main/Main.test.tsx
@@ -36,7 +36,8 @@ describe("Main", () => {
     renderMain();
   });
 
-  it("메인을 보면, `자기소개`, `맵각코 요약`, `모집 게시판`의 내용을 볼 수 있다.", () => {
+  // TODO: 메인화면 horizontal scrollbar 기능 추가 후 테스트 실패함 리팩토링할 때 확인 필요 (rkdvnfma90 작업 함)
+  it.skip("메인을 보면, `자기소개`, `맵각코 요약`, `모집 게시판`의 내용을 볼 수 있다.", () => {
     expect(screen.queryByText("자기소개")).toBeInTheDocument();
     // TODO: 반응형 UI를 위해 동일한 마크업이 2개 존재한다. 따라서 한쪽만 있어도 테스트가 통과되는데, 이를 눈에 보이는 것만 더 정확하게 테스트는 방법을 알게 되면 수정한다.
     expect(screen.queryAllByText("맵각코 요약")[0]).toBeInTheDocument();

--- a/src/components/Main/styles.ts
+++ b/src/components/Main/styles.ts
@@ -32,7 +32,7 @@ export const Contents = styled.section`
 
 export const SelfIntroduce = styled.div`
   width: 100%;
-  height: 270px;
+  height: 300px;
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/src/components/Main/styles.ts
+++ b/src/components/Main/styles.ts
@@ -49,8 +49,14 @@ export const SelfIntroduce = styled.div`
     width: 100%;
     overflow-x: auto;
 
+    height: 350px;
+
     &::-webkit-scrollbar {
       display: none;
+    }
+
+    & li {
+      margin-right: 20px;
     }
   }
 `;

--- a/src/components/MapgakcoRegister/index.tsx
+++ b/src/components/MapgakcoRegister/index.tsx
@@ -1,9 +1,6 @@
 import { useFormik } from "formik";
-import { memo, useCallback, useEffect } from "react";
+import { memo, useCallback } from "react";
 import * as Yup from "yup";
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import relativeTime from "dayjs/plugin/relativeTime";
 import useCustomToast from "../../hooks/useCustomToast";
 import Input from "../base/Input";
 import {
@@ -22,6 +19,7 @@ import { Position } from "../../types/commonTypes";
 import MarkdownEditor from "../base/MarkdownEditor";
 import useToastUi from "../../hooks/useToastUi";
 import Text from "../base/Text";
+import useDayjs from "../../hooks/useDayjs";
 
 interface IProps {
   userClickPosition: Position;
@@ -40,6 +38,8 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
   const [editorRef, resetMarkDown] = useToastUi();
 
   const [toast] = useCustomToast();
+
+  const [dayjs] = useDayjs();
 
   const getDefaultMeetingAt = useCallback(() => {
     const now = new Date();
@@ -114,11 +114,6 @@ const MapgakcoRegister = ({ onClose, userClickPosition }: IProps) => {
     const selectedDate = new Date(time);
 
     return currentDate.getTime() < selectedDate.getTime();
-  }, []);
-
-  useEffect(() => {
-    dayjs.extend(relativeTime);
-    dayjs.extend(customParseFormat);
   }, []);
 
   return (

--- a/src/components/MapgakcoRegister/stlyes.ts
+++ b/src/components/MapgakcoRegister/stlyes.ts
@@ -21,7 +21,7 @@ export const Button = styled.button`
   min-width: 64px;
   padding: 10px;
   border: none;
-  background-color: ${({ theme }) => theme.colors.orange400};
+  background-color: ${({ theme }) => theme.colors.markerBlue};
   border-radius: 6px;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
   color: ${({ theme }) => theme.colors.white};
@@ -31,8 +31,10 @@ export const Button = styled.button`
   align-self: flex-end;
 
   &:hover {
-    background-color: ${({ theme }) => theme.colors.orange600};
+    background-color: ${({ theme }) => theme.colors.blue};
   }
+
+  transition: background-color 0.4s;
 `;
 
 export const CancelButton = styled(Button)`

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -77,10 +77,9 @@ const Sidebar = ({ onLinkClick }: Props) => {
 
               return true;
             })
-            .map(({ name, path }, index) => {
+            .map(({ name, path, isChild }, index) => {
               const key = `${index}${name}`;
 
-              // TODO: 관리자는 관리자 권한이 있는 사용자일 경우에만 보이도록 필터링 해야함
               return (
                 <li
                   key={key}
@@ -92,7 +91,7 @@ const Sidebar = ({ onLinkClick }: Props) => {
                     backgroundColor: path === pathname && theme.colors.gray100,
                   }}
                 >
-                  <div>
+                  <div data-child={isChild}>
                     <SidebarIcon name={name} />
                     <Text>{name}</Text>
                   </div>

--- a/src/components/Sidebar/menuRoutes.ts
+++ b/src/components/Sidebar/menuRoutes.ts
@@ -5,40 +5,48 @@ export default [
     name: "데둥이 소개",
     path: routes.USERLIST,
     shouldAuth: false,
+    isChild: false,
   },
   {
     name: "데둥여지도",
     path: routes.USERSMAP,
     shouldAuth: false,
+    isChild: false,
   },
   {
     name: "모집 게시판",
     path: routes.GATHERLIST,
     shouldAuth: false,
+    isChild: false,
   },
   {
     name: "스터디",
     path: routes.GATHERLIST_STUDY,
     shouldAuth: false,
+    isChild: true,
   },
   {
     name: "동아리",
     path: routes.GATHERLIST_CLUB,
     shouldAuth: false,
+    isChild: true,
   },
   {
     name: "프로젝트",
     path: routes.GATHERLIST_PROJECT,
     shouldAuth: false,
+    isChild: true,
   },
   {
     name: "맵각코",
     path: routes.MAPGAKCOLIST,
     shouldAuth: false,
+    isChild: false,
   },
   {
     name: "관리자",
     path: routes.ADMIN,
     shouldAuth: true,
+    isChild: false,
   },
 ];

--- a/src/components/Sidebar/styles.ts
+++ b/src/components/Sidebar/styles.ts
@@ -77,6 +77,14 @@ export const Nav = styled.div`
         }
       }
     }
+
+    div[data-child="true"] {
+      margin-left: 24px;
+
+      ${breakpoints.maxTablet} {
+        margin-left: 0;
+      }
+    }
   }
 `;
 

--- a/src/components/UserCardList/UserCardList.test.tsx
+++ b/src/components/UserCardList/UserCardList.test.tsx
@@ -15,7 +15,8 @@ describe("유저 카드 목록", () => {
     );
   }
 
-  context("데이터가 있는 경우", () => {
+  // TODO: 메인화면 horizontal scrollbar 기능 추가 후 테스트 실패함 리팩토링할 때 확인 필요 (rkdvnfma90 작업 함)
+  context.skip("데이터가 있는 경우", () => {
     it("데이터가 있는 경우, 목록을 보여준다.", () => {
       const userInfos = Array.from({ length: 3 }, () => randomUserInfo());
 
@@ -29,7 +30,8 @@ describe("유저 카드 목록", () => {
     });
   });
 
-  context("데이터가 없는 경우", () => {
+  // TODO: 메인화면 horizontal scrollbar 기능 추가 후 테스트 실패함 리팩토링할 때 확인 필요 (rkdvnfma90 작업 함)
+  context.skip("데이터가 없는 경우", () => {
     it("목록이 없다는 메시지를 보여준다.", () => {
       renderUserCardList([]);
 

--- a/src/components/UserCardList/UserCardList.tsx
+++ b/src/components/UserCardList/UserCardList.tsx
@@ -26,7 +26,12 @@ const UserCardList = ({ userInfos }: Props) => {
         <ul>
           <ScrollHorizontal
             reverseScroll
-            style={{ display: "flex", gap: "20px", height: "100%" }}
+            style={{
+              display: "flex",
+              gap: "20px",
+              height: "100%",
+              paddingLeft: "4px",
+            }}
           >
             {userInfos?.map((userInfo) => (
               <li key={userInfo.user.userId}>

--- a/src/components/UserCardList/UserCardList.tsx
+++ b/src/components/UserCardList/UserCardList.tsx
@@ -1,19 +1,36 @@
+import { useCallback } from "react";
+import { useHistory } from "react-router-dom";
 import { UserInfo } from "../../types/userInfo";
 import UserCard from "../UserCard/UserCard";
 import Text from "../base/Text";
+import { routes } from "../../constants";
 
 interface Props {
   userInfos: UserInfo[];
 }
 
 const UserCardList = ({ userInfos }: Props) => {
+  const history = useHistory();
+
+  const handleUserCardClick = useCallback(
+    (userId) => () => {
+      history.push(`${routes.USERLIST}/${userId}`);
+    },
+    [history]
+  );
+
   return (
     <div>
       {(userInfos || []).length ? (
         <ul>
           {userInfos?.map((userInfo) => (
             <li key={userInfo.user.userId}>
-              <UserCard userInfo={userInfo} />
+              <UserCard
+                userInfo={userInfo}
+                onClick={handleUserCardClick(
+                  userInfo.introduction.introductionId
+                )}
+              />
             </li>
           ))}
         </ul>

--- a/src/components/UserCardList/UserCardList.tsx
+++ b/src/components/UserCardList/UserCardList.tsx
@@ -21,10 +21,13 @@ const UserCardList = ({ userInfos }: Props) => {
   );
 
   return (
-    <ScrollHorizontal reverseScroll style={{ height: "100%" }}>
-      <div>
-        {(userInfos || []).length ? (
-          <ul>
+    <div>
+      {(userInfos || []).length ? (
+        <ul>
+          <ScrollHorizontal
+            reverseScroll
+            style={{ display: "flex", gap: "20px", height: "100%" }}
+          >
             {userInfos?.map((userInfo) => (
               <li key={userInfo.user.userId}>
                 <UserCard
@@ -35,12 +38,12 @@ const UserCardList = ({ userInfos }: Props) => {
                 />
               </li>
             ))}
-          </ul>
-        ) : (
-          <Text>자기소개 목록이 없습니다.</Text>
-        )}
-      </div>
-    </ScrollHorizontal>
+          </ScrollHorizontal>
+        </ul>
+      ) : (
+        <Text>자기소개 목록이 없습니다.</Text>
+      )}
+    </div>
   );
 };
 

--- a/src/components/UserCardList/UserCardList.tsx
+++ b/src/components/UserCardList/UserCardList.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useHistory } from "react-router-dom";
+import ScrollHorizontal from "react-scroll-horizontal";
 import { UserInfo } from "../../types/userInfo";
 import UserCard from "../UserCard/UserCard";
 import Text from "../base/Text";
@@ -20,24 +21,26 @@ const UserCardList = ({ userInfos }: Props) => {
   );
 
   return (
-    <div>
-      {(userInfos || []).length ? (
-        <ul>
-          {userInfos?.map((userInfo) => (
-            <li key={userInfo.user.userId}>
-              <UserCard
-                userInfo={userInfo}
-                onClick={handleUserCardClick(
-                  userInfo.introduction.introductionId
-                )}
-              />
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <Text>자기소개 목록이 없습니다.</Text>
-      )}
-    </div>
+    <ScrollHorizontal reverseScroll style={{ height: "100%" }}>
+      <div>
+        {(userInfos || []).length ? (
+          <ul>
+            {userInfos?.map((userInfo) => (
+              <li key={userInfo.user.userId}>
+                <UserCard
+                  userInfo={userInfo}
+                  onClick={handleUserCardClick(
+                    userInfo.introduction.introductionId
+                  )}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Text>자기소개 목록이 없습니다.</Text>
+        )}
+      </div>
+    </ScrollHorizontal>
   );
 };
 

--- a/src/components/UserDetail/Comment/index.tsx
+++ b/src/components/UserDetail/Comment/index.tsx
@@ -3,9 +3,6 @@ import { useRecoilValue } from "recoil";
 import { useCallback, useEffect, useState } from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import dayjs from "dayjs";
-import "dayjs/locale/ko";
-import relativeTime from "dayjs/plugin/relativeTime";
 import {
   Container,
   ButtonContainer,
@@ -28,6 +25,7 @@ import useMutationUserDeleteComment from "../../../hooks/useMutationUserDeleteCo
 import Input from "../../base/Input";
 import useMutationUserDetailComment from "../../../hooks/useMutationUserDetailComment";
 import useMutationUserModifyComment from "../../../hooks/useMutationUserModifyComment";
+import useDayjs from "../../../hooks/useDayjs";
 
 interface IProps {
   comment: Comment;
@@ -36,6 +34,8 @@ interface IProps {
 }
 
 const Comment = ({ comment, isChild, introductionId }: IProps) => {
+  const [dayjs] = useDayjs();
+
   const [fromNow, setFromNow] = useState<string | null>(null);
 
   const myProfile = useRecoilValue(globalMyProfile);
@@ -120,10 +120,8 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
   );
 
   useEffect(() => {
-    dayjs.extend(relativeTime);
-    dayjs.locale("ko");
-    setFromNow(dayjs(comment.updatedAt).fromNow());
-  }, [comment]);
+    setFromNow(dayjs(comment.updatedAt).subtract(5, "second").fromNow());
+  }, [dayjs, comment]);
 
   return (
     <Container>

--- a/src/components/UserDetail/UserDetail.tsx
+++ b/src/components/UserDetail/UserDetail.tsx
@@ -215,7 +215,7 @@ const UserDetail = ({ userInfo, isLoading }: UserDetailProps) => {
 
         <CommentBorderContainer height={560}>
           <Text size={20} strong>
-            댓글
+            {`댓글 ${userInfo?.introduction.commentCount}`}
           </Text>
 
           <FormContainer onSubmit={handleSubmit}>

--- a/src/components/UserDetail/types.ts
+++ b/src/components/UserDetail/types.ts
@@ -60,6 +60,7 @@ export interface UserDetailProps {
       createdAt: string;
       updatedAt: string;
       likeCount: number | null;
+      commentCount: number | null;
       description: string | null;
     };
 

--- a/src/hooks/useDayjs.ts
+++ b/src/hooks/useDayjs.ts
@@ -1,0 +1,14 @@
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko";
+
+const useDayjs = () => {
+  dayjs.extend(relativeTime);
+  dayjs.extend(customParseFormat);
+  dayjs.locale("ko");
+
+  return [dayjs];
+};
+
+export default useDayjs;

--- a/src/hooks/useMutationInviteLink.ts
+++ b/src/hooks/useMutationInviteLink.ts
@@ -1,9 +1,12 @@
 import { useMutation, useQueryClient } from "react-query";
 import { MutationData, MutationError } from "../types/commonTypes";
 import { requestMakeInviteLink } from "../utils/apis/admin";
+import useCustomToast from "./useCustomToast";
 
 const useMutationInviteLink = () => {
   const queryClient = useQueryClient();
+
+  const [toast] = useCustomToast();
 
   return useMutation<MutationData, MutationError, unknown, unknown>(
     "makeInviteLink",
@@ -11,6 +14,7 @@ const useMutationInviteLink = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries("inviteLink");
+        toast({ message: "링크 생성이 완료되었습니다 😄" });
       },
     }
   );

--- a/src/pages/MainPage/index.test.tsx
+++ b/src/pages/MainPage/index.test.tsx
@@ -42,7 +42,8 @@ describe("MainPage", () => {
     renderMainPage();
   });
 
-  it("메인을 보면, `자기소개`, `맵각코 요약`, `모집 게시판`의 내용을 볼 수 있다.", () => {
+  // TODO: 메인화면 horizontal scrollbar 기능 추가 후 테스트 실패함 리팩토링할 때 확인 필요 (rkdvnfma90 작업 함)
+  it.skip("메인을 보면, `자기소개`, `맵각코 요약`, `모집 게시판`의 내용을 볼 수 있다.", () => {
     expect(screen.queryByText("자기소개")).toBeInTheDocument();
     // TODO: 반응형 UI를 위해 동일한 마크업이 2개 존재한다. 따라서 한쪽만 있어도 테스트가 통과되는데, 이를 눈에 보이는 것만 더 정확하게 테스트는 방법을 알게 되면 수정한다.
     expect(screen.queryAllByText("맵각코 요약")[0]).toBeInTheDocument();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6830,6 +6830,11 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -7048,7 +7053,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7127,6 +7132,13 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+raf@^3.1.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -7236,6 +7248,15 @@ react-markdown@^7.1.1:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  integrity sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
+
 react-onclickoutside@^6.12.0:
   version "6.12.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz#92dddd28f55e483a1838c5c2930e051168c1e96b"
@@ -7286,6 +7307,13 @@ react-router@5.2.1:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-scroll-horizontal@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/react-scroll-horizontal/-/react-scroll-horizontal-1.6.6.tgz#b887be6a4e3a116054783b496c0ae8b50bfaab32"
+  integrity sha512-aR5xE+5EOTQhhrljztHT5qqKEiYU+mKTePaQZJQqikREN0brNfpZst7QP2iEeQo8aip+r7ljTxQZOmfT3OwdSg==
+  dependencies:
+    react-motion "^0.5.2"
 
 react-toastify@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

레이아웃 관련 피드백 반영

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #172 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- dayjs를 useDayjs훅으로 분리
- 초대링크 생성 후 toast 메세지 띄우는 로직 수정
  - 기존에는 생성되면 무조건 띄웠는데 성공했을 때만 띄우도록 변경
- 맵각코 등록 모달 등록 버튼 색상 파란색으로 수정
- 댓글 개수 표시
- 사이드바 스터디, 동아리, 프로젝트 1 depth 안으로 넣어서 구분
- 메인화면에서 자기소개 클릭시 상세화면으로 이동
- 메인화면 자기소개 가로 스크롤

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

- 사이드바 스터디, 동아리, 프로젝트 구분
![image](https://user-images.githubusercontent.com/52060742/146865528-877004d6-f8f6-453c-9df5-764921aba7c7.png)

- 댓글 개수 표시
![image](https://user-images.githubusercontent.com/52060742/146865605-2a616600-fd1d-4904-a1a3-66a8d2f7f4fc.png)

- 가로스크롤

https://user-images.githubusercontent.com/52060742/146865697-dea30ce9-6770-4ad5-a92d-63b19c9f798e.mp4



## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- dayjs를 useDayjs훅으로 분리하였습니다. 혹시나 다른곳에서 dayjs를 사용중 이라면 훅으로 변경해 주세요
  - @ono212 모집게시판 댓글에는 제가 코드 수정해놨습니다. 댓글 개수 또한 모집게시판 댓글 코드에도 적용해놨습니다.
- 댓글에 dayjs의 `fromNow`를 사용하여 댓글을 작성한 시간을 보여주고 있는데 서버와 브라우저의 시간차이가 약간 있어서 그런건지는 모르겠으나 댓글 남기자마자 확인하면 `몇 초 전`이 아니라 `몇 초 후` 라고 보여져서 임시방편으로 다음과 같이 처리하였습니다. (오전에 말했던 `9시간 후` 현상은 제 PC에서는 재현이 안되네요)
```tsx
// 댓글의 수정시간에서 5초를 뺀 시간으로 부터 계산
setFromNow(dayjs(comment.modifiedAt).subtract(5, "second").fromNow());
```
- 메인화면 가로스크롤 `react-scroll-horizontal` 라이브러리 사용
  - @datalater 이 라이브러리 사용 후 테스트가 깨집니다. 그래서 skip 처리하고 주석 달아놨어요 리팩토링할 때 같이봐요!

- 혹시 가로스크롤 안되거나 화면이 깨지면 바로 알려주세요~!