### PR TITLE
DVT-#174 유저 드랍다운 메뉴 버그 해결

### DIFF
--- a/src/components/UserImageAndDropdown/UserImageAndDropdown.tsx
+++ b/src/components/UserImageAndDropdown/UserImageAndDropdown.tsx
@@ -12,8 +12,8 @@ const UserImageAndDropdown = ({ imageUrl, onLinkClick }: Props) => {
   const [ref, isHovered] = useHover();
 
   return (
-    <Container>
-      <ImageWrapper ref={ref}>
+    <Container ref={ref}>
+      <ImageWrapper>
         <UserProfileImage imageUrl={imageUrl} />
       </ImageWrapper>
       <DropdownWrapper>


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

유저 프로필 이미지에 마우스 오버했다가 드랍다운 메뉴로 커서를 이동했을 때 드랍다운 메뉴가 사라지는 버그를 해결한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #175 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 유저 프로필 이미지에 마우스 오버했다가 드랍다운 메뉴로 커서를 이동했을 때 드랍다운 메뉴가 사라지는 버그를 해결한다.

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

https://user-images.githubusercontent.com/8105528/146888976-48239f1f-bbdc-465a-9e72-2b1ebc6195fa.mov


## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음