### PR TITLE
DVT-#194 메인화면 자기소개 흔들리는 레이아웃 버그해결

### DIFF
--- a/src/components/UserCardList/UserCardList.tsx
+++ b/src/components/UserCardList/UserCardList.tsx
@@ -33,16 +33,18 @@ const UserCardList = ({ userInfos }: Props) => {
               paddingLeft: "4px",
             }}
           >
-            {userInfos?.map((userInfo) => (
-              <li key={userInfo.user.userId}>
-                <UserCard
-                  userInfo={userInfo}
-                  onClick={handleUserCardClick(
-                    userInfo.introduction.introductionId
-                  )}
-                />
-              </li>
-            ))}
+            <div style={{ display: "flex", width: "110vw" }}>
+              {userInfos?.map((userInfo) => (
+                <li key={userInfo.user.userId}>
+                  <UserCard
+                    userInfo={userInfo}
+                    onClick={handleUserCardClick(
+                      userInfo.introduction.introductionId
+                    )}
+                  />
+                </li>
+              ))}
+            </div>
           </ScrollHorizontal>
         </ul>
       ) : (


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

메인화면 자기소개 가로 스크롤에서 좌우로 흔들리는 레이아웃 버그해결

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #194 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 라이브러리 설명에 따라 `<HorizontalScroll>`의 자식 컴포넌트의 너비가 `<HorizontalScroll>`의 너비보다 더 크게 설정한다.

Link: https://www.npmjs.com/package/react-scroll-horizontal

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

![image](https://user-images.githubusercontent.com/8105528/146978521-503bd6a2-4fed-4ebf-965a-912802dcba98.png)

자기소개 개수가 적어서 부모 컴포넌트보다 너비가 작을 때 흔들리는 현상이 사라졌습니다.

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음
