### PR TITLE
DVT-#203 맵각코 페이지에서 검색을 마치면 검색 결과 제거

### DIFF
--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -148,7 +148,8 @@ const MapgakcoMap = ({
     justifyContent: "center",
     borderRadius: "8px",
     boxShadow: theme.boxShadows.primary,
-  };
+    whiteSpace: "nowrap",
+  } as React.CSSProperties;
 
   const registerButtonStyle = {
     ...buttonStyle,

--- a/src/components/MapgakcoMap/PlaceSearchForm.tsx
+++ b/src/components/MapgakcoMap/PlaceSearchForm.tsx
@@ -26,6 +26,8 @@ const PlaceSearchForm = ({ onSubmit }: Props) => {
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       onSubmit(searchResults[0]);
+
+      setContent("");
     },
     [onSubmit, searchResults]
   );


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

맵각코 페이지에서 검색을 마치면 검색 결과 창 없애기

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #203 

## ✅ 체크리스트

> 구현한 내용 체크리스트

- [x] 맵각코 페이지에서 검색을 마치면 검색 결과 창 없애기
- [x] 뷰포트가 줄어들어도 맵각코 페이지 버튼의 글씨가 두 줄로 뭉개지지 않도록 수정

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

https://user-images.githubusercontent.com/8105528/147891872-6209d328-cedf-4ecf-a38a-f67ba7af96dc.mov

- 맵각코 페이지에서 검색을 마치면 검색 결과 창 없애기
- 뷰포트가 줄어들어도 맵각코 페이지 버튼의 글씨가 두 줄로 뭉개지지 않도록 수정

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- `whiteSpace` 속성은 `React.CSSProperties` 타입에서 제공하지 않는 타입이라 타입 단언을 사용하여 타입 오류를 해결합니다.


