### PR TITLE
DVT-#207 대댓글 값 버그 수정

### DIFF
--- a/src/components/UserDetail/Comment/index.tsx
+++ b/src/components/UserDetail/Comment/index.tsx
@@ -58,7 +58,7 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
           `댓글은 ${common.validation.COMMENT_MAX_LENGTH}자이상 작성할 수 없습니다`
         ),
     }),
-    onSubmit: (formValues, { setSubmitting, resetForm }) => {
+    onSubmit: (formValues, { setSubmitting }) => {
       setSubmitting(true);
       userModifyCommentMutate({
         introductionId,
@@ -67,7 +67,6 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
       });
       setSubmitting(false);
       toggleModify();
-      resetForm();
     },
   });
 
@@ -81,7 +80,7 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
           `댓글은 ${common.validation.COMMENT_MAX_LENGTH}자이상 작성할 수 없습니다`
         ),
     }),
-    onSubmit: (formValues, { setSubmitting, resetForm }) => {
+    onSubmit: (formValues, { setSubmitting }) => {
       setSubmitting(true);
       userWriteChildCommentMutate({
         introductionId,
@@ -90,7 +89,6 @@ const Comment = ({ comment, isChild, introductionId }: IProps) => {
       });
       setSubmitting(false);
       toggleChildComment();
-      resetForm();
     },
   });
 


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

대댓글 값 버그 수정

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #207 

## ✅ 체크리스트

> PR 양식 체크리스트

- [x] 리뷰어 설정
- [x] 할당자 설정
- [x] 레이블 설정
- [x] 프로젝트 설정

> 구현한 내용 체크리스트

- [x] 대댓글 값 버그 수정

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

없음

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

- onSubmit 후 `resetForm()`을 하였는데 이 부분때문에 이전값으로 되돌아 갔음. 제거하여 해결
