### PR TITLE
DVT-#236 사이드바에 프로필 메뉴 추가 및 데둥여지도 기수 셀렉트 박스의 옵션 수정

### DIFF
--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -6,6 +6,8 @@ import {
   BsStar,
   BsLaptop,
   BsMap,
+  BsPerson,
+  BsExclamationCircle,
 } from "react-icons/bs";
 import { GrUserAdmin } from "react-icons/gr";
 
@@ -15,6 +17,7 @@ interface Props {
 
 const SidebarIcon = ({ name }: Props) => {
   const Map = {
+    프로필: <BsPerson />,
     "데둥이 소개": <BsPeople />,
     데둥여지도: <BsPinMap />,
     "모집 게시판": <BsClipboardCheck />,
@@ -25,7 +28,7 @@ const SidebarIcon = ({ name }: Props) => {
     관리자: <GrUserAdmin />,
   };
 
-  return Map[name];
+  return Map[name] || <BsExclamationCircle />;
 };
 
 export default SidebarIcon;

--- a/src/components/Sidebar/menuRoutes.ts
+++ b/src/components/Sidebar/menuRoutes.ts
@@ -2,6 +2,12 @@ import { routes } from "../../constants";
 
 export default [
   {
+    name: "프로필",
+    path: routes.MYPROFILE,
+    shouldAuth: false,
+    isChild: false,
+  },
+  {
     name: "데둥이 소개",
     path: routes.USERLIST,
     shouldAuth: false,

--- a/src/components/UsersMap/UsersMap.tsx
+++ b/src/components/UsersMap/UsersMap.tsx
@@ -89,7 +89,10 @@ const UsersMap = ({ center, currentUser, onSearchedUserClick }: Props) => {
               value={formik.values.generation}
             >
               <option value="">{common.text.GENERATION}</option>
-              {common.generations.map(({ value, label }) => (
+              {[
+                { value: "1", label: "1기" },
+                { value: "2", label: "2기" },
+              ].map(({ value, label }) => (
                 <option key={value} value={value}>
                   {label}
                 </option>


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

사이드바에 프로필 메뉴 추가 및 데둥여지도 기수 셀렉트 박스의 옵션 수정

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #236 

## ✅ 체크리스트

> 구현한 내용 체크리스트

- [ ] 사이드바에 프로필 메뉴 추가
- [ ] 데둥여지도 기수 셀렉트 박스의 옵션 수정

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/8105528/154901080-a8adc620-3f23-4d66-8deb-df34e9d6d497.png">

- 사이드바에 프로필 메뉴를 추가하여 유저가 프로필 메뉴를 쉽게 찾을 수 있게 유도했습니다.

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음
