### PR TITLE
DVT-#240 사이드바 및 탑바의 가시 여부를 조절하는 불필요한 useEffect 제거

### DIFF
--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import AdminContainer from "../../components/Admin/AdminContainer";
 
 const AdminPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <AdminContainer />;
 };

--- a/src/pages/GatherClubPage/index.tsx
+++ b/src/pages/GatherClubPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherClubPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <GatherMainContainer selectedCategory="CLUB" />;
 };

--- a/src/pages/GatherDetailPage/index.tsx
+++ b/src/pages/GatherDetailPage/index.tsx
@@ -1,14 +1,11 @@
-import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherDetailContainer from "../../components/GatherDetail/GatherDetailContainer";
 
 const GatherDetailPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+  setShowSidebar(true);
 
   return <GatherDetailContainer />;
 };

--- a/src/pages/GatherPage/index.tsx
+++ b/src/pages/GatherPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <GatherMainContainer />;
 };

--- a/src/pages/GatherProjectPage/index.tsx
+++ b/src/pages/GatherProjectPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherProjectPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <GatherMainContainer selectedCategory="PROJECT" />;
 };

--- a/src/pages/GatherStudyPage/index.tsx
+++ b/src/pages/GatherStudyPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherStudyPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <GatherMainContainer selectedCategory="STUDY" />;
 };

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,17 +1,14 @@
-import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import LoginContainer from "../../components/Login/LoginContainer";
 
 const LoginPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(false);
-    setShowTopbar(false);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+  setShowSidebar(false);
+  setShowTopbar(false);
 
   return <LoginContainer />;
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MainContainer from "../../components/Main/MainContainer";
 
 const MainPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, setShowSidebar, setShowTopbar, resetTopbarBgColor]);
+  setShowSidebar(true);
+  setShowTopbar(true);
+  resetTopbarBgColor();
 
   return <MainContainer />;
 };

--- a/src/pages/MapgakcoMapPage/index.tsx
+++ b/src/pages/MapgakcoMapPage/index.tsx
@@ -1,17 +1,14 @@
-import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MapgakcoMapContainer from "../../components/MapgakcoMap/MapgakcoMapContainer";
 
 const MapgakCoMapPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(false);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(false);
 
   return <MapgakcoMapContainer />;
 };

--- a/src/pages/MyGatherPage/index.tsx
+++ b/src/pages/MyGatherPage/index.tsx
@@ -1,17 +1,14 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import MyGatherContainer from "../../components/MyGather/MyGatherContainer";
 
 const MyGatherPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar]);
+  setShowSidebar(true);
+  resetTopbarBgColor();
 
   return <MyGatherContainer />;
 };

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MyProfileContainer from "../../components/MyProfile/MyProfileContainer";
 
 const MyProfilePage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowTopbar(true);
+  setShowSidebar(true);
+  resetTopbarBgColor();
 
   return <MyProfileContainer />;
 };

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -1,6 +1,6 @@
 import Lottie from "react-lottie";
-import { useCallback, useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useCallback } from "react";
+import { useSetRecoilState } from "recoil";
 import { useHistory } from "react-router-dom";
 import animationData from "../../assets/lotties/404-error.json";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
@@ -10,15 +10,13 @@ import { routes } from "../../constants";
 const NotFoundPage = () => {
   const history = useHistory();
 
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
+
+  setShowSidebar(false);
 
   const handleClick = useCallback(() => {
     history.push(routes.MAIN);
   }, [history]);
-
-  useEffect(() => {
-    setShowSidebar(false);
-  }, [isShowSidebar, setShowSidebar]);
 
   return (
     <Container>

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,17 +1,14 @@
-import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import SignupContainer from "../../components/Signup/SignupContainer";
 
 const index = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(false);
-    setShowTopbar(false);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+  setShowSidebar(false);
+  setShowTopbar(false);
 
   return <SignupContainer />;
 };

--- a/src/pages/UserDetailPage/index.tsx
+++ b/src/pages/UserDetailPage/index.tsx
@@ -1,14 +1,11 @@
-import { useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import UserDetailContainer from "../../components/UserDetail/UserDetailContainer";
 
 const UserDetailPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-  }, [isShowSidebar, setShowSidebar]);
+  setShowSidebar(true);
 
   return <UserDetailContainer />;
 };

--- a/src/pages/UserListPage/index.tsx
+++ b/src/pages/UserListPage/index.tsx
@@ -1,20 +1,17 @@
-import { useEffect } from "react";
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UserListContainer from "../../components/UserList/UserListContainer";
 
 const UserListPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(true);
-    resetTopbarBgColor();
-  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
+  setShowTopbar(true);
+  setShowSidebar(true);
+  resetTopbarBgColor();
 
   return <UserListContainer />;
 };

--- a/src/pages/UsersMapPage/index.tsx
+++ b/src/pages/UsersMapPage/index.tsx
@@ -1,17 +1,14 @@
-import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UsersMapContainer from "../../components/UsersMap/UsersMapContainer";
 
 const UserMapPage = () => {
-  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
+  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  useEffect(() => {
-    setShowSidebar(true);
-    setShowTopbar(false);
-  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
+  setShowSidebar(true);
+  setShowTopbar(false);
 
   return <UsersMapContainer />;
 };


### PR DESCRIPTION
## 💁 설명

> 무엇에 대한 PR인지 설명해주세요.

사이드바 및 탑바의 가시 여부를 조절하는 불필요한 useEffect 제거

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #240 

## ✅ 체크리스트

> 구현한 내용 체크리스트

- [ ] 사이드바 및 탑바의 가시 여부를 조절하는 불필요한 useEffect 제거 (모든 페이지에서 기존처럼 나오는지 테스트 완료)

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

없음

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음
