### PR TITLE
DVT-#242 맵각코 상세 등록 모달에 지정된 장소 추가 및 맵각코 주소 검색 결과 빈칸 초기화

### DIFF
--- a/src/components/MapgakcoMap/MapFloatControl/index.tsx
+++ b/src/components/MapgakcoMap/MapFloatControl/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   isUsersVisible: boolean;
   isMapgakcosVisible: boolean;
   isRegisterEnabled: boolean;
+  isUserClicked: boolean;
   toggleVisibleUsers: () => void;
   toggleVisibleMapgakcos: () => void;
   onRegisterClick: () => void;
@@ -35,6 +36,7 @@ const MapFloatControl = ({
   isUsersVisible,
   isMapgakcosVisible,
   isRegisterEnabled,
+  isUserClicked,
   toggleVisibleUsers,
   toggleVisibleMapgakcos,
   onMyPositionClick,
@@ -45,7 +47,10 @@ const MapFloatControl = ({
     <>
       <SearchContainer>
         <PlaceSearchFormWrapper>
-          <PlaceSearchForm onSubmit={onKeywordSearchSubmit} />
+          <PlaceSearchForm
+            isUserClicked={isUserClicked}
+            onSubmit={onKeywordSearchSubmit}
+          />
         </PlaceSearchFormWrapper>
         <ButtonContainer>
           <MyPositionButton onClick={onMyPositionClick}>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -25,6 +25,10 @@ import {
   Slider,
   SliderContainer,
 } from "./styles";
+import { PlaceModel } from "../../types/place";
+import useCoord2Address from "../../hooks/useCoord2Address";
+import { toCoordFromPosition } from "../../utils/map/coord";
+import { Coord2AddressModel } from "../../types/coord2Address";
 
 interface Props {
   initialCenter: Position;
@@ -73,6 +77,8 @@ const MapgakcoMap = ({
   const memoCenter = useRef(initialCenter);
 
   const [userClickPosition, click, initializeClick] = useMapClick();
+  const { data: coord2Addresses }: { data: Coord2AddressModel[] } =
+    useCoord2Address(toCoordFromPosition(userClickPosition));
 
   const [isUsersVisible, toggleVisibleUsers] = useToggle(false);
   const [isMapgakcosVisible, toggleVisibleMapgakcos] = useToggle(true);
@@ -91,18 +97,22 @@ const MapgakcoMap = ({
   const [isDetailPanelOpen, setDetailPanelOpen] = useState<boolean>(false);
   const [isMarkerSelected, setIsMarkerSelected] = useState<boolean>(false);
   const [selectedMapgakco, setSelectedMapgakco] = useState(null);
+  const [selectedPlace, setSelectedPlace] = useState<PlaceModel | null>(null);
+  const [placename, setPlacename] = useState<string>("");
 
   const handleKeywordSubmit = useCallback(
-    (place) => {
+    (place: PlaceModel) => {
       setTargetPlace((prev) => ({
         ...prev,
         ...place,
       }));
 
       setCenter({
-        lat: place.y,
-        lng: place.x,
+        lat: +place.y,
+        lng: +place.x,
       });
+
+      setSelectedPlace(place);
 
       initializeClick();
     },
@@ -199,6 +209,28 @@ const MapgakcoMap = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const coord2Address = coord2Addresses?.[0];
+
+    const addressName = coord2Address?.road_address
+      ? coord2Address?.road_address?.address_name
+      : coord2Address?.address
+      ? coord2Address?.address?.address_name
+      : "검색되지 않는 지번 주소입니다.";
+
+    const newPlacename =
+      userClickPosition.lat === null && userClickPosition.lng === null
+        ? selectedPlace?.road_address_name
+        : addressName;
+
+    setPlacename(newPlacename || "");
+  }, [
+    coord2Addresses,
+    userClickPosition.lat,
+    userClickPosition.lng,
+    selectedPlace,
+  ]);
+
   return (
     <Container>
       <MapFloatControlWrapper
@@ -225,6 +257,7 @@ const MapgakcoMap = ({
             targetPlace,
             initialCenter
           )}
+          placename={placename}
           onClose={handleRegisterModalClose}
         />
       </Modal>

--- a/src/components/MapgakcoMap/MapgakcoMap.tsx
+++ b/src/components/MapgakcoMap/MapgakcoMap.tsx
@@ -213,6 +213,9 @@ const MapgakcoMap = ({
           onMyPositionClick={handleMyPositionClick}
           onKeywordSearchSubmit={handleKeywordSubmit}
           onRegisterClick={handleRegisterClick}
+          isUserClicked={
+            userClickPosition.lat !== null && userClickPosition.lng !== null
+          }
         />
       </MapFloatControlWrapper>
       <Modal visible={isRegisterModalOpen} width="60%">

--- a/src/components/MapgakcoMap/PlaceSearchForm/PlaceSearchForm.tsx
+++ b/src/components/MapgakcoMap/PlaceSearchForm/PlaceSearchForm.tsx
@@ -1,4 +1,10 @@
-import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+import {
+  ChangeEvent,
+  FormEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import useSearchResults from "../../../hooks/useSearchResults";
 import { Input } from "../../base/Input";
 import {
@@ -9,13 +15,20 @@ import {
 import SearchResultList from "./SearchResultList";
 
 interface Props {
+  isUserClicked: boolean;
   onSubmit: (inputValue: string) => void;
 }
 
-const PlaceSearchForm = ({ onSubmit }: Props) => {
+const PlaceSearchForm = ({ isUserClicked, onSubmit }: Props) => {
   const [content, setContent] = useState("");
 
   const { data: searchResults } = useSearchResults(content);
+
+  const inputStyle = {
+    fontSize: "16px",
+    padding: "12px",
+    borderRadius: "8px",
+  };
 
   const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -40,11 +53,11 @@ const PlaceSearchForm = ({ onSubmit }: Props) => {
     [onSubmit]
   );
 
-  const inputStyle = {
-    fontSize: "16px",
-    padding: "12px",
-    borderRadius: "8px",
-  };
+  useEffect(() => {
+    if (isUserClicked) {
+      setContent("");
+    }
+  }, [isUserClicked]);
 
   return (
     <PlaceSearchFromContainer>

--- a/src/components/MapgakcoMap/PlaceSearchForm/PlaceSearchForm.tsx
+++ b/src/components/MapgakcoMap/PlaceSearchForm/PlaceSearchForm.tsx
@@ -39,7 +39,7 @@ const PlaceSearchForm = ({ isUserClicked, onSubmit }: Props) => {
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      onSubmit(searchResults[0]);
+      onSubmit(searchResults?.[0]);
 
       setContent("");
     },

--- a/src/components/MapgakcoMap/PlaceSearchForm/SearchResultList.tsx
+++ b/src/components/MapgakcoMap/PlaceSearchForm/SearchResultList.tsx
@@ -1,8 +1,8 @@
-import { ResponsePlace } from "../../../types/place";
+import { PlaceModel } from "../../../types/place";
 
 interface Props {
-  results: ResponsePlace[];
-  onClick: (place: ResponsePlace) => () => void;
+  results: PlaceModel[];
+  onClick: (place: PlaceModel) => () => void;
 }
 
 const SearchResultList = ({ results, onClick }: Props) => {

--- a/src/components/MapgakcoRegister/index.tsx
+++ b/src/components/MapgakcoRegister/index.tsx
@@ -23,6 +23,7 @@ import useDayjs from "../../hooks/useDayjs";
 
 interface IProps {
   markerPosition: Position;
+  placename: string;
   onClose: () => void;
 }
 
@@ -34,7 +35,7 @@ interface FormValues {
   content: string;
 }
 
-const MapgakcoRegister = ({ markerPosition, onClose }: IProps) => {
+const MapgakcoRegister = ({ markerPosition, placename, onClose }: IProps) => {
   const [editorRef, resetMarkDown] = useToastUi();
 
   const [toast] = useCustomToast();
@@ -173,6 +174,13 @@ const MapgakcoRegister = ({ markerPosition, onClose }: IProps) => {
           {touched.title && !!errors.title && (
             <ErrorMessage>{errors.title}</ErrorMessage>
           )}
+        </InputContainer>
+
+        <InputContainer>
+          <label htmlFor="location">
+            <Text strong>장소</Text>
+          </label>
+          <Input type="text" name="location" value={placename} disabled />
         </InputContainer>
 
         <InputContainer>

--- a/src/constants/searchApi.ts
+++ b/src/constants/searchApi.ts
@@ -1,3 +1,4 @@
 export const url = {
   MAP_KEYWORD_SEARCH: "v2/local/search/keyword.json",
+  COORD2ADDRESS: "/v2/local/geo/coord2address.json",
 };

--- a/src/hooks/useCoord2Address.ts
+++ b/src/hooks/useCoord2Address.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "react-query";
+import { CartesianPosition } from "../types/commonTypes";
+import { requestCoord2Address } from "../utils/apis/coord2Address";
+
+const toAddressFromCoord = async (coord: CartesianPosition) => {
+  if (!coord.x || !coord.y) {
+    return undefined;
+  }
+
+  const { data } = await requestCoord2Address(coord);
+
+  return data?.documents;
+};
+
+export default function useCoord2Address(coord: CartesianPosition) {
+  return useQuery(["coord2Address", coord], () => toAddressFromCoord(coord));
+}

--- a/src/pages/AdminPage/index.tsx
+++ b/src/pages/AdminPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import AdminContainer from "../../components/Admin/AdminContainer";
 
 const AdminPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <AdminContainer />;
 };

--- a/src/pages/GatherClubPage/index.tsx
+++ b/src/pages/GatherClubPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherClubPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="CLUB" />;
 };

--- a/src/pages/GatherDetailPage/index.tsx
+++ b/src/pages/GatherDetailPage/index.tsx
@@ -1,11 +1,14 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import GatherDetailContainer from "../../components/GatherDetail/GatherDetailContainer";
 
 const GatherDetailPage = () => {
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
 
-  setShowSidebar(true);
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
 
   return <GatherDetailContainer />;
 };

--- a/src/pages/GatherPage/index.tsx
+++ b/src/pages/GatherPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer />;
 };

--- a/src/pages/GatherProjectPage/index.tsx
+++ b/src/pages/GatherProjectPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherProjectPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="PROJECT" />;
 };

--- a/src/pages/GatherStudyPage/index.tsx
+++ b/src/pages/GatherStudyPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import GatherMainContainer from "../../components/GatherMain/GatherMainContainer";
 
 const GatherStudyPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <GatherMainContainer selectedCategory="STUDY" />;
 };

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,14 +1,17 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import LoginContainer from "../../components/Login/LoginContainer";
 
 const LoginPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  setShowSidebar(false);
-  setShowTopbar(false);
+  useEffect(() => {
+    setShowSidebar(false);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <LoginContainer />;
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MainContainer from "../../components/Main/MainContainer";
 
 const MainPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  setShowTopbar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, setShowSidebar, setShowTopbar, resetTopbarBgColor]);
 
   return <MainContainer />;
 };

--- a/src/pages/MapgakcoMapPage/index.tsx
+++ b/src/pages/MapgakcoMapPage/index.tsx
@@ -1,14 +1,17 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MapgakcoMapContainer from "../../components/MapgakcoMap/MapgakcoMapContainer";
 
 const MapgakCoMapPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  setShowSidebar(true);
-  setShowTopbar(false);
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <MapgakcoMapContainer />;
 };

--- a/src/pages/MyGatherPage/index.tsx
+++ b/src/pages/MyGatherPage/index.tsx
@@ -1,14 +1,17 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import MyGatherContainer from "../../components/MyGather/MyGatherContainer";
 
 const MyGatherPage = () => {
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowSidebar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar]);
 
   return <MyGatherContainer />;
 };

--- a/src/pages/MyProfilePage/index.tsx
+++ b/src/pages/MyProfilePage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import MyProfileContainer from "../../components/MyProfile/MyProfileContainer";
 
 const MyProfilePage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowTopbar(true);
-  setShowSidebar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <MyProfileContainer />;
 };

--- a/src/pages/NotFoundPage/index.tsx
+++ b/src/pages/NotFoundPage/index.tsx
@@ -1,6 +1,6 @@
 import Lottie from "react-lottie";
-import { useCallback } from "react";
-import { useSetRecoilState } from "recoil";
+import { useCallback, useEffect } from "react";
+import { useRecoilState } from "recoil";
 import { useHistory } from "react-router-dom";
 import animationData from "../../assets/lotties/404-error.json";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
@@ -10,13 +10,15 @@ import { routes } from "../../constants";
 const NotFoundPage = () => {
   const history = useHistory();
 
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
-
-  setShowSidebar(false);
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
 
   const handleClick = useCallback(() => {
     history.push(routes.MAIN);
   }, [history]);
+
+  useEffect(() => {
+    setShowSidebar(false);
+  }, [isShowSidebar, setShowSidebar]);
 
   return (
     <Container>

--- a/src/pages/SignupPage/index.tsx
+++ b/src/pages/SignupPage/index.tsx
@@ -1,14 +1,17 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import SignupContainer from "../../components/Signup/SignupContainer";
 
 const index = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  setShowSidebar(false);
-  setShowTopbar(false);
+  useEffect(() => {
+    setShowSidebar(false);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <SignupContainer />;
 };

--- a/src/pages/UserDetailPage/index.tsx
+++ b/src/pages/UserDetailPage/index.tsx
@@ -1,11 +1,14 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import UserDetailContainer from "../../components/UserDetail/UserDetailContainer";
 
 const UserDetailPage = () => {
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
 
-  setShowSidebar(true);
+  useEffect(() => {
+    setShowSidebar(true);
+  }, [isShowSidebar, setShowSidebar]);
 
   return <UserDetailContainer />;
 };

--- a/src/pages/UserListPage/index.tsx
+++ b/src/pages/UserListPage/index.tsx
@@ -1,17 +1,20 @@
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarBgColorState } from "../../atoms/topbarBgColor";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UserListContainer from "../../components/UserList/UserListContainer";
 
 const UserListPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
   const resetTopbarBgColor = useResetRecoilState(topbarBgColorState);
 
-  setShowTopbar(true);
-  setShowSidebar(true);
-  resetTopbarBgColor();
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(true);
+    resetTopbarBgColor();
+  }, [isShowSidebar, resetTopbarBgColor, setShowSidebar, setShowTopbar]);
 
   return <UserListContainer />;
 };

--- a/src/pages/UsersMapPage/index.tsx
+++ b/src/pages/UsersMapPage/index.tsx
@@ -1,14 +1,17 @@
-import { useSetRecoilState } from "recoil";
+import { useEffect } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import { sidebarVisibleState } from "../../atoms/sidebarVisible";
 import { topbarVisibleState } from "../../atoms/topbarVisble";
 import UsersMapContainer from "../../components/UsersMap/UsersMapContainer";
 
 const UserMapPage = () => {
+  const [isShowSidebar, setShowSidebar] = useRecoilState(sidebarVisibleState);
   const setShowTopbar = useSetRecoilState(topbarVisibleState);
-  const setShowSidebar = useSetRecoilState(sidebarVisibleState);
 
-  setShowSidebar(true);
-  setShowTopbar(false);
+  useEffect(() => {
+    setShowSidebar(true);
+    setShowTopbar(false);
+  }, [isShowSidebar, setShowSidebar, setShowTopbar]);
 
   return <UsersMapContainer />;
 };

--- a/src/types/coord2Address.ts
+++ b/src/types/coord2Address.ts
@@ -1,0 +1,27 @@
+interface RoadAddressModel {
+  address_name: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  road_name: string;
+  underground_yn: string;
+  main_building_no: string;
+  sub_building_no: string;
+  building_name: string;
+  zone_no: string;
+}
+
+interface AddressModel {
+  address_name: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  mountain_yn: string;
+  main_address_no: string;
+  sub_address_no: string;
+}
+
+export interface Coord2AddressModel {
+  road_address: RoadAddressModel;
+  address: AddressModel;
+}

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -1,4 +1,4 @@
-export interface ResponsePlace {
+export interface PlaceModel {
   id: string;
   place_name: string;
   category_name: string;

--- a/src/utils/apis/coord2Address.ts
+++ b/src/utils/apis/coord2Address.ts
@@ -1,0 +1,7 @@
+import { url } from "../../constants/searchApi";
+import { CartesianPosition } from "../../types/commonTypes";
+import mapAxiosInstance from "./mapAxiosInstance";
+
+export const requestCoord2Address = (coord: CartesianPosition) => {
+  return mapAxiosInstance.get(`${url.COORD2ADDRESS}?x=${coord.x}&y=${coord.y}`);
+};

--- a/src/utils/map/coord.ts
+++ b/src/utils/map/coord.ts
@@ -1,0 +1,8 @@
+import { CartesianPosition, Position } from "../../types/commonTypes";
+
+export const toCoordFromPosition = (position: Position): CartesianPosition => {
+  return {
+    x: position.lng,
+    y: position.lat,
+  };
+};


### PR DESCRIPTION
## 💁 설명

맵각코 상세 등록 모달에 지정된 장소를 표시하고, 사용자가 다른 위치를 클릭할 경우 맵각코 주소 검색 결과를 빈칸으로 초기화한다.

## 🔗 연결된 이슈

> 머지가 완료되면 연결된 이슈가 자동으로 닫히도록 closes 키워드 뒤에 이슈 번호를 적습니다. `ex. closes #1`

closes #242 

## ✅ 체크리스트

> PR 양식 체크리스트

> 구현한 내용 체크리스트

- [x] 맵각코 상세 등록 모달에 지정된 장소 추가
- [x] 사용자가 다른 위치를 클릭할 경우 맵각코 주소 검색 결과 빈칸 초기화한다.
- [x] 사이드바 가시 여부를 조정할 때 useEffect를 사용했던 커밋을 복원한다. (useEffect를 제거하면 에러가 발생하기 때문)

## 변경된 기능

> 가능하다면 어떤 기능이 변경되었는지 알 수 있도록 스크린샷 또는 짧은 동영상을 첨부해주세요.

<img width="801" alt="image" src="https://user-images.githubusercontent.com/8105528/155489524-206f0e09-05c8-4a60-87ed-dc9b2f97e686.png">

- 사용자가 지도에서 클릭하거나 검색을 완료한 장소가 맵각코 등록 모달에 표시됩니다.

## 🚨 주의사항

> PR을 읽을 때 살펴볼 사항

없음
